### PR TITLE
Make building HOAUGens optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(NOVA_SIMD "Build VBAP with nova-simd support." ON)
 option(CPP11 "Build with c++11." ON)
 option(NATIVE "Optimize for this specific machine." OFF)
 option(SYSTEM_STK "Use STK libraries from system" OFF)
-
+option(HOA_UGENS "Build with HOAUGens" OFF)
 option(NOVA_DISK_IO "Build with Nova's DiskIO UGens. Requires boost source tree, break warranty & eats your children." OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -93,7 +93,6 @@ set(PLUGIN_DIRS
     DistortionUGens
     DWGUGens
     GlitchUGens
-    HOAUGens
     JoshUGens
     LoopBufUGens
     MCLDUGens
@@ -165,12 +164,15 @@ else()
     set(INSTALL_DESTINATION_DISTRO "SC3plugins")
 endif()
 
-#HOAUGens
-if (CMAKE_COMPILER_IS_CLANG)
-    file(GLOB HOAUGensSources HOAUGens/*cpp)
-    foreach(HOAUGensSourceFile ${HOAUGensSources})
-	  set_source_files_properties("${HOAUGensSourceFile}" PROPERTIES COMPILE_FLAGS "-fbracket-depth=4096")
-    endforeach(HOAUGensSourceFile)
+# HOAUGens
+if (HOA_UGENS)
+    list(APPEND PLUGIN_DIRS HOAUGens)
+    if (CMAKE_COMPILER_IS_CLANG)
+        file(GLOB HOAUGensSources HOAUGens/*cpp)
+        foreach(HOAUGensSourceFile ${HOAUGensSources})
+            set_source_files_properties("${HOAUGensSourceFile}" PROPERTIES COMPILE_FLAGS "-fbracket-depth=4096")
+        endforeach(HOAUGensSourceFile)
+    endif()
 endif()
 
 foreach(DIR ${PLUGIN_DIRS})


### PR DESCRIPTION
This PR adds an option that allows conditional building of the HOAUGens. The reasons for this option being set to `OFF` by default are the following:

- These plugins cannot be build on Windows MSVC due too some files having very deep bracket nesting.
- Embedded Linux systems like Rpi aren't able to build, likely due to their limited resources.
- As is, the sc3-plugins are build-able on all systems. Having this option set to `ON` by default would change that. It's better to require users to opt-in to these plugins.

This PR is a starting point. I'm hoping to bring renewed attention to supercollider/sc3-plugins#146, and  get things merged soon.

@djiamnot @nicobou
