### PR TITLE
added alternative "light weight" encoders and optimizer

### DIFF
--- a/source/HOAUGens/HOALibEnc3D1.cpp
+++ b/source/HOAUGens/HOALibEnc3D1.cpp
@@ -1,0 +1,1118 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibEnc3D1"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	FAUSTFLOAT fHslider1;
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibEnc3D1");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibEnc3D1");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 4;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibEnc3D1");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		float fSlow0 = (float(fHslider0) + 3.14159274f);
+		float fSlow1 = cosf((1.57079637f - float(fHslider1)));
+		float fSlow2 = (0.0f - sqrtf((1.0f - mydsp_faustpower2_f(fSlow1))));
+		float fSlow3 = (1.0f * (sinf(fSlow0) * fSlow2));
+		float fSlow4 = (1.0f * (fSlow2 * cosf(fSlow0)));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			output1[i] = FAUSTFLOAT((fSlow3 * fTemp0));
+			output2[i] = FAUSTFLOAT((fSlow1 * fTemp0));
+			output3[i] = FAUSTFLOAT((fSlow4 * fTemp0));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibEnc3D2.cpp
+++ b/source/HOAUGens/HOALibEnc3D2.cpp
@@ -1,0 +1,1159 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibEnc3D2"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	FAUSTFLOAT fHslider1;
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibEnc3D2");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibEnc3D2");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 9;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibEnc3D2");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		float fSlow0 = (float(fHslider0) + 3.14159274f);
+		float fSlow1 = cosf((1.57079637f - float(fHslider1)));
+		float fSlow2 = mydsp_faustpower2_f(fSlow1);
+		float fSlow3 = sqrtf((1.0f - fSlow2));
+		float fSlow4 = (0.0f - fSlow3);
+		float fSlow5 = (sinf(fSlow0) * fSlow4);
+		float fSlow6 = (1.0f * fSlow5);
+		float fSlow7 = (fSlow4 * cosf(fSlow0));
+		float fSlow8 = (1.0f * fSlow7);
+		float fSlow9 = (fSlow4 * (0.0f - (3.0f * fSlow3)));
+		float fSlow10 = (2.0f * fSlow0);
+		float fSlow11 = (0.288675129f * (fSlow9 * sinf(fSlow10)));
+		float fSlow12 = (1.73205078f * (fSlow5 * fSlow1));
+		float fSlow13 = (0.5f * ((3.0f * fSlow2) + -1.0f));
+		float fSlow14 = (1.73205078f * (fSlow7 * fSlow1));
+		float fSlow15 = (0.288675129f * (fSlow9 * cosf(fSlow10)));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			output1[i] = FAUSTFLOAT((fSlow6 * fTemp0));
+			output2[i] = FAUSTFLOAT((fSlow1 * fTemp0));
+			output3[i] = FAUSTFLOAT((fSlow8 * fTemp0));
+			output4[i] = FAUSTFLOAT((fSlow11 * fTemp0));
+			output5[i] = FAUSTFLOAT((fSlow12 * fTemp0));
+			output6[i] = FAUSTFLOAT((fSlow13 * fTemp0));
+			output7[i] = FAUSTFLOAT((fSlow14 * fTemp0));
+			output8[i] = FAUSTFLOAT((fSlow15 * fTemp0));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibEnc3D3.cpp
+++ b/source/HOAUGens/HOALibEnc3D3.cpp
@@ -1,0 +1,1215 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibEnc3D3"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	FAUSTFLOAT fHslider1;
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibEnc3D3");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibEnc3D3");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 16;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibEnc3D3");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		float fSlow0 = (float(fHslider0) + 3.14159274f);
+		float fSlow1 = cosf((1.57079637f - float(fHslider1)));
+		float fSlow2 = mydsp_faustpower2_f(fSlow1);
+		float fSlow3 = sqrtf((1.0f - fSlow2));
+		float fSlow4 = (0.0f - fSlow3);
+		float fSlow5 = (sinf(fSlow0) * fSlow4);
+		float fSlow6 = (1.0f * fSlow5);
+		float fSlow7 = (fSlow4 * cosf(fSlow0));
+		float fSlow8 = (1.0f * fSlow7);
+		float fSlow9 = (fSlow4 * (0.0f - (3.0f * fSlow3)));
+		float fSlow10 = (2.0f * fSlow0);
+		float fSlow11 = sinf(fSlow10);
+		float fSlow12 = (0.288675129f * (fSlow9 * fSlow11));
+		float fSlow13 = (1.73205078f * (fSlow5 * fSlow1));
+		float fSlow14 = ((3.0f * fSlow2) + -1.0f);
+		float fSlow15 = (0.5f * fSlow14);
+		float fSlow16 = (1.73205078f * (fSlow7 * fSlow1));
+		float fSlow17 = cosf(fSlow10);
+		float fSlow18 = (0.288675129f * (fSlow9 * fSlow17));
+		float fSlow19 = (fSlow9 * (0.0f - (5.0f * fSlow3)));
+		float fSlow20 = (3.0f * fSlow0);
+		float fSlow21 = (0.0527046286f * (fSlow19 * sinf(fSlow20)));
+		float fSlow22 = (fSlow9 * fSlow1);
+		float fSlow23 = (0.645497203f * (fSlow22 * fSlow11));
+		float fSlow24 = ((15.0f * fSlow2) + -3.0f);
+		float fSlow25 = (0.204124153f * (fSlow5 * fSlow24));
+		float fSlow26 = (0.333333343f * (((2.5f * fSlow14) + -2.0f) * fSlow1));
+		float fSlow27 = (0.204124153f * (fSlow7 * fSlow24));
+		float fSlow28 = (0.645497203f * (fSlow22 * fSlow17));
+		float fSlow29 = (0.0527046286f * (fSlow19 * cosf(fSlow20)));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			output1[i] = FAUSTFLOAT((fSlow6 * fTemp0));
+			output2[i] = FAUSTFLOAT((fSlow1 * fTemp0));
+			output3[i] = FAUSTFLOAT((fSlow8 * fTemp0));
+			output4[i] = FAUSTFLOAT((fSlow12 * fTemp0));
+			output5[i] = FAUSTFLOAT((fSlow13 * fTemp0));
+			output6[i] = FAUSTFLOAT((fSlow15 * fTemp0));
+			output7[i] = FAUSTFLOAT((fSlow16 * fTemp0));
+			output8[i] = FAUSTFLOAT((fSlow18 * fTemp0));
+			output9[i] = FAUSTFLOAT((fSlow21 * fTemp0));
+			output10[i] = FAUSTFLOAT((fSlow23 * fTemp0));
+			output11[i] = FAUSTFLOAT((fSlow25 * fTemp0));
+			output12[i] = FAUSTFLOAT((fSlow26 * fTemp0));
+			output13[i] = FAUSTFLOAT((fSlow27 * fTemp0));
+			output14[i] = FAUSTFLOAT((fSlow28 * fTemp0));
+			output15[i] = FAUSTFLOAT((fSlow29 * fTemp0));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibEnc3D4.cpp
+++ b/source/HOAUGens/HOALibEnc3D4.cpp
@@ -1,0 +1,1286 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibEnc3D4"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	FAUSTFLOAT fHslider1;
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibEnc3D4");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibEnc3D4");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 25;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibEnc3D4");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		float fSlow0 = (float(fHslider0) + 3.14159274f);
+		float fSlow1 = cosf((1.57079637f - float(fHslider1)));
+		float fSlow2 = mydsp_faustpower2_f(fSlow1);
+		float fSlow3 = sqrtf((1.0f - fSlow2));
+		float fSlow4 = (0.0f - fSlow3);
+		float fSlow5 = (sinf(fSlow0) * fSlow4);
+		float fSlow6 = (1.0f * fSlow5);
+		float fSlow7 = (fSlow4 * cosf(fSlow0));
+		float fSlow8 = (1.0f * fSlow7);
+		float fSlow9 = (fSlow4 * (0.0f - (3.0f * fSlow3)));
+		float fSlow10 = (2.0f * fSlow0);
+		float fSlow11 = sinf(fSlow10);
+		float fSlow12 = (0.288675129f * (fSlow9 * fSlow11));
+		float fSlow13 = (1.73205078f * (fSlow5 * fSlow1));
+		float fSlow14 = ((3.0f * fSlow2) + -1.0f);
+		float fSlow15 = (0.5f * fSlow14);
+		float fSlow16 = (1.73205078f * (fSlow7 * fSlow1));
+		float fSlow17 = cosf(fSlow10);
+		float fSlow18 = (0.288675129f * (fSlow9 * fSlow17));
+		float fSlow19 = (fSlow9 * (0.0f - (5.0f * fSlow3)));
+		float fSlow20 = (3.0f * fSlow0);
+		float fSlow21 = sinf(fSlow20);
+		float fSlow22 = (0.0527046286f * (fSlow19 * fSlow21));
+		float fSlow23 = (fSlow9 * fSlow1);
+		float fSlow24 = (0.645497203f * (fSlow23 * fSlow11));
+		float fSlow25 = ((15.0f * fSlow2) + -3.0f);
+		float fSlow26 = (0.204124153f * (fSlow5 * fSlow25));
+		float fSlow27 = ((2.5f * fSlow14) + -2.0f);
+		float fSlow28 = (0.333333343f * (fSlow27 * fSlow1));
+		float fSlow29 = (0.204124153f * (fSlow7 * fSlow25));
+		float fSlow30 = (0.645497203f * (fSlow23 * fSlow17));
+		float fSlow31 = cosf(fSlow20);
+		float fSlow32 = (0.0527046286f * (fSlow19 * fSlow31));
+		float fSlow33 = (fSlow19 * (0.0f - (7.0f * fSlow3)));
+		float fSlow34 = (4.0f * fSlow0);
+		float fSlow35 = (0.00704295235f * (fSlow33 * sinf(fSlow34)));
+		float fSlow36 = (fSlow19 * fSlow1);
+		float fSlow37 = (0.139443338f * (fSlow36 * fSlow21));
+		float fSlow38 = (fSlow9 * ((35.0f * fSlow2) + -5.0f));
+		float fSlow39 = (0.0372678004f * (fSlow38 * fSlow11));
+		float fSlow40 = ((3.5f * fSlow25) + -12.0f);
+		float fSlow41 = (0.105409257f * ((fSlow5 * fSlow40) * fSlow1));
+		float fSlow42 = (0.25f * ((2.33333325f * (fSlow27 * fSlow2)) - (1.5f * fSlow14)));
+		float fSlow43 = (0.105409257f * ((fSlow7 * fSlow40) * fSlow1));
+		float fSlow44 = (0.0372678004f * (fSlow38 * fSlow17));
+		float fSlow45 = (0.139443338f * (fSlow36 * fSlow31));
+		float fSlow46 = (0.00704295235f * (fSlow33 * cosf(fSlow34)));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			output1[i] = FAUSTFLOAT((fSlow6 * fTemp0));
+			output2[i] = FAUSTFLOAT((fSlow1 * fTemp0));
+			output3[i] = FAUSTFLOAT((fSlow8 * fTemp0));
+			output4[i] = FAUSTFLOAT((fSlow12 * fTemp0));
+			output5[i] = FAUSTFLOAT((fSlow13 * fTemp0));
+			output6[i] = FAUSTFLOAT((fSlow15 * fTemp0));
+			output7[i] = FAUSTFLOAT((fSlow16 * fTemp0));
+			output8[i] = FAUSTFLOAT((fSlow18 * fTemp0));
+			output9[i] = FAUSTFLOAT((fSlow22 * fTemp0));
+			output10[i] = FAUSTFLOAT((fSlow24 * fTemp0));
+			output11[i] = FAUSTFLOAT((fSlow26 * fTemp0));
+			output12[i] = FAUSTFLOAT((fSlow28 * fTemp0));
+			output13[i] = FAUSTFLOAT((fSlow29 * fTemp0));
+			output14[i] = FAUSTFLOAT((fSlow30 * fTemp0));
+			output15[i] = FAUSTFLOAT((fSlow32 * fTemp0));
+			output16[i] = FAUSTFLOAT((fSlow35 * fTemp0));
+			output17[i] = FAUSTFLOAT((fSlow37 * fTemp0));
+			output18[i] = FAUSTFLOAT((fSlow39 * fTemp0));
+			output19[i] = FAUSTFLOAT((fSlow41 * fTemp0));
+			output20[i] = FAUSTFLOAT((fSlow42 * fTemp0));
+			output21[i] = FAUSTFLOAT((fSlow43 * fTemp0));
+			output22[i] = FAUSTFLOAT((fSlow44 * fTemp0));
+			output23[i] = FAUSTFLOAT((fSlow45 * fTemp0));
+			output24[i] = FAUSTFLOAT((fSlow46 * fTemp0));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibEnc3D5.cpp
+++ b/source/HOAUGens/HOALibEnc3D5.cpp
@@ -1,0 +1,1373 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibEnc3D5"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	FAUSTFLOAT fHslider1;
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibEnc3D5");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibEnc3D5");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 36;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			case 25: {
+				rate = 1;
+				break;
+			}
+			case 26: {
+				rate = 1;
+				break;
+			}
+			case 27: {
+				rate = 1;
+				break;
+			}
+			case 28: {
+				rate = 1;
+				break;
+			}
+			case 29: {
+				rate = 1;
+				break;
+			}
+			case 30: {
+				rate = 1;
+				break;
+			}
+			case 31: {
+				rate = 1;
+				break;
+			}
+			case 32: {
+				rate = 1;
+				break;
+			}
+			case 33: {
+				rate = 1;
+				break;
+			}
+			case 34: {
+				rate = 1;
+				break;
+			}
+			case 35: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibEnc3D5");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		FAUSTFLOAT* output25 = outputs[25];
+		FAUSTFLOAT* output26 = outputs[26];
+		FAUSTFLOAT* output27 = outputs[27];
+		FAUSTFLOAT* output28 = outputs[28];
+		FAUSTFLOAT* output29 = outputs[29];
+		FAUSTFLOAT* output30 = outputs[30];
+		FAUSTFLOAT* output31 = outputs[31];
+		FAUSTFLOAT* output32 = outputs[32];
+		FAUSTFLOAT* output33 = outputs[33];
+		FAUSTFLOAT* output34 = outputs[34];
+		FAUSTFLOAT* output35 = outputs[35];
+		float fSlow0 = (float(fHslider0) + 3.14159274f);
+		float fSlow1 = cosf((1.57079637f - float(fHslider1)));
+		float fSlow2 = mydsp_faustpower2_f(fSlow1);
+		float fSlow3 = sqrtf((1.0f - fSlow2));
+		float fSlow4 = (0.0f - fSlow3);
+		float fSlow5 = (sinf(fSlow0) * fSlow4);
+		float fSlow6 = (1.0f * fSlow5);
+		float fSlow7 = (fSlow4 * cosf(fSlow0));
+		float fSlow8 = (1.0f * fSlow7);
+		float fSlow9 = (fSlow4 * (0.0f - (3.0f * fSlow3)));
+		float fSlow10 = (2.0f * fSlow0);
+		float fSlow11 = sinf(fSlow10);
+		float fSlow12 = (0.288675129f * (fSlow9 * fSlow11));
+		float fSlow13 = (1.73205078f * (fSlow5 * fSlow1));
+		float fSlow14 = ((3.0f * fSlow2) + -1.0f);
+		float fSlow15 = (0.5f * fSlow14);
+		float fSlow16 = (1.73205078f * (fSlow7 * fSlow1));
+		float fSlow17 = cosf(fSlow10);
+		float fSlow18 = (0.288675129f * (fSlow9 * fSlow17));
+		float fSlow19 = (fSlow9 * (0.0f - (5.0f * fSlow3)));
+		float fSlow20 = (3.0f * fSlow0);
+		float fSlow21 = sinf(fSlow20);
+		float fSlow22 = (0.0527046286f * (fSlow19 * fSlow21));
+		float fSlow23 = (fSlow9 * fSlow1);
+		float fSlow24 = (0.645497203f * (fSlow23 * fSlow11));
+		float fSlow25 = ((15.0f * fSlow2) + -3.0f);
+		float fSlow26 = (0.204124153f * (fSlow5 * fSlow25));
+		float fSlow27 = ((2.5f * fSlow14) + -2.0f);
+		float fSlow28 = (0.333333343f * (fSlow27 * fSlow1));
+		float fSlow29 = (0.204124153f * (fSlow7 * fSlow25));
+		float fSlow30 = (0.645497203f * (fSlow23 * fSlow17));
+		float fSlow31 = cosf(fSlow20);
+		float fSlow32 = (0.0527046286f * (fSlow19 * fSlow31));
+		float fSlow33 = (fSlow19 * (0.0f - (7.0f * fSlow3)));
+		float fSlow34 = (4.0f * fSlow0);
+		float fSlow35 = sinf(fSlow34);
+		float fSlow36 = (0.00704295235f * (fSlow33 * fSlow35));
+		float fSlow37 = (fSlow19 * fSlow1);
+		float fSlow38 = (0.139443338f * (fSlow37 * fSlow21));
+		float fSlow39 = ((35.0f * fSlow2) + -5.0f);
+		float fSlow40 = (fSlow9 * fSlow39);
+		float fSlow41 = (0.0372678004f * (fSlow40 * fSlow11));
+		float fSlow42 = ((3.5f * fSlow25) + -12.0f);
+		float fSlow43 = (0.105409257f * ((fSlow5 * fSlow42) * fSlow1));
+		float fSlow44 = ((2.33333325f * (fSlow27 * fSlow2)) - (1.5f * fSlow14));
+		float fSlow45 = (0.25f * fSlow44);
+		float fSlow46 = (0.105409257f * ((fSlow7 * fSlow42) * fSlow1));
+		float fSlow47 = (0.0372678004f * (fSlow40 * fSlow17));
+		float fSlow48 = (0.139443338f * (fSlow37 * fSlow31));
+		float fSlow49 = cosf(fSlow34);
+		float fSlow50 = (0.00704295235f * (fSlow33 * fSlow49));
+		float fSlow51 = (fSlow33 * (0.0f - (9.0f * fSlow3)));
+		float fSlow52 = (5.0f * fSlow0);
+		float fSlow53 = (0.000742392323f * (fSlow51 * sinf(fSlow52)));
+		float fSlow54 = (fSlow33 * fSlow1);
+		float fSlow55 = (0.0211288556f * (fSlow54 * fSlow35));
+		float fSlow56 = (fSlow19 * ((63.0f * fSlow2) + -7.0f));
+		float fSlow57 = (0.00498011941f * (fSlow56 * fSlow21));
+		float fSlow58 = ((fSlow9 * ((4.5f * fSlow39) + -30.0f)) * fSlow1);
+		float fSlow59 = (0.0162650011f * (fSlow58 * fSlow11));
+		float fSlow60 = ((3.0f * (fSlow42 * fSlow2)) - (2.5f * fSlow25));
+		float fSlow61 = (0.0645497218f * (fSlow5 * fSlow60));
+		float fSlow62 = (0.200000003f * (((2.25f * fSlow44) - (1.33333337f * fSlow27)) * fSlow1));
+		float fSlow63 = (0.0645497218f * (fSlow7 * fSlow60));
+		float fSlow64 = (0.0162650011f * (fSlow58 * fSlow17));
+		float fSlow65 = (0.00498011941f * (fSlow56 * fSlow31));
+		float fSlow66 = (0.0211288556f * (fSlow54 * fSlow49));
+		float fSlow67 = (0.000742392323f * (fSlow51 * cosf(fSlow52)));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			output1[i] = FAUSTFLOAT((fSlow6 * fTemp0));
+			output2[i] = FAUSTFLOAT((fSlow1 * fTemp0));
+			output3[i] = FAUSTFLOAT((fSlow8 * fTemp0));
+			output4[i] = FAUSTFLOAT((fSlow12 * fTemp0));
+			output5[i] = FAUSTFLOAT((fSlow13 * fTemp0));
+			output6[i] = FAUSTFLOAT((fSlow15 * fTemp0));
+			output7[i] = FAUSTFLOAT((fSlow16 * fTemp0));
+			output8[i] = FAUSTFLOAT((fSlow18 * fTemp0));
+			output9[i] = FAUSTFLOAT((fSlow22 * fTemp0));
+			output10[i] = FAUSTFLOAT((fSlow24 * fTemp0));
+			output11[i] = FAUSTFLOAT((fSlow26 * fTemp0));
+			output12[i] = FAUSTFLOAT((fSlow28 * fTemp0));
+			output13[i] = FAUSTFLOAT((fSlow29 * fTemp0));
+			output14[i] = FAUSTFLOAT((fSlow30 * fTemp0));
+			output15[i] = FAUSTFLOAT((fSlow32 * fTemp0));
+			output16[i] = FAUSTFLOAT((fSlow36 * fTemp0));
+			output17[i] = FAUSTFLOAT((fSlow38 * fTemp0));
+			output18[i] = FAUSTFLOAT((fSlow41 * fTemp0));
+			output19[i] = FAUSTFLOAT((fSlow43 * fTemp0));
+			output20[i] = FAUSTFLOAT((fSlow45 * fTemp0));
+			output21[i] = FAUSTFLOAT((fSlow46 * fTemp0));
+			output22[i] = FAUSTFLOAT((fSlow47 * fTemp0));
+			output23[i] = FAUSTFLOAT((fSlow48 * fTemp0));
+			output24[i] = FAUSTFLOAT((fSlow50 * fTemp0));
+			output25[i] = FAUSTFLOAT((fSlow53 * fTemp0));
+			output26[i] = FAUSTFLOAT((fSlow55 * fTemp0));
+			output27[i] = FAUSTFLOAT((fSlow57 * fTemp0));
+			output28[i] = FAUSTFLOAT((fSlow59 * fTemp0));
+			output29[i] = FAUSTFLOAT((fSlow61 * fTemp0));
+			output30[i] = FAUSTFLOAT((fSlow62 * fTemp0));
+			output31[i] = FAUSTFLOAT((fSlow63 * fTemp0));
+			output32[i] = FAUSTFLOAT((fSlow64 * fTemp0));
+			output33[i] = FAUSTFLOAT((fSlow65 * fTemp0));
+			output34[i] = FAUSTFLOAT((fSlow66 * fTemp0));
+			output35[i] = FAUSTFLOAT((fSlow67 * fTemp0));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibInPhase3D1.cpp
+++ b/source/HOAUGens/HOALibInPhase3D1.cpp
@@ -1,0 +1,1113 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibInPhase3D1"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibInPhase3D1");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibInPhase3D1");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 4;
+		
+	}
+	virtual int getNumOutputs() {
+		return 4;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibInPhase3D1");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.5f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.5f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.5f * float(input3[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibInPhase3D2.cpp
+++ b/source/HOAUGens/HOALibInPhase3D2.cpp
@@ -1,0 +1,1168 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibInPhase3D2"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibInPhase3D2");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibInPhase3D2");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 9;
+		
+	}
+	virtual int getNumOutputs() {
+		return 9;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibInPhase3D2");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.666666687f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.666666687f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.666666687f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.166666672f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.166666672f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.166666672f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.166666672f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.166666672f * float(input8[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibInPhase3D3.cpp
+++ b/source/HOAUGens/HOALibInPhase3D3.cpp
@@ -1,0 +1,1245 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibInPhase3D3"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibInPhase3D3");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibInPhase3D3");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 16;
+		
+	}
+	virtual int getNumOutputs() {
+		return 16;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibInPhase3D3");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* input9 = inputs[9];
+		FAUSTFLOAT* input10 = inputs[10];
+		FAUSTFLOAT* input11 = inputs[11];
+		FAUSTFLOAT* input12 = inputs[12];
+		FAUSTFLOAT* input13 = inputs[13];
+		FAUSTFLOAT* input14 = inputs[14];
+		FAUSTFLOAT* input15 = inputs[15];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.75f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.75f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.75f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.300000012f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.300000012f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.300000012f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.300000012f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.300000012f * float(input8[i])));
+			output9[i] = FAUSTFLOAT((0.0500000007f * float(input9[i])));
+			output10[i] = FAUSTFLOAT((0.0500000007f * float(input10[i])));
+			output11[i] = FAUSTFLOAT((0.0500000007f * float(input11[i])));
+			output12[i] = FAUSTFLOAT((0.0500000007f * float(input12[i])));
+			output13[i] = FAUSTFLOAT((0.0500000007f * float(input13[i])));
+			output14[i] = FAUSTFLOAT((0.0500000007f * float(input14[i])));
+			output15[i] = FAUSTFLOAT((0.0500000007f * float(input15[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibInPhase3D4.cpp
+++ b/source/HOAUGens/HOALibInPhase3D4.cpp
@@ -1,0 +1,1344 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibInPhase3D4"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibInPhase3D4");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibInPhase3D4");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 25;
+		
+	}
+	virtual int getNumOutputs() {
+		return 25;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibInPhase3D4");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* input9 = inputs[9];
+		FAUSTFLOAT* input10 = inputs[10];
+		FAUSTFLOAT* input11 = inputs[11];
+		FAUSTFLOAT* input12 = inputs[12];
+		FAUSTFLOAT* input13 = inputs[13];
+		FAUSTFLOAT* input14 = inputs[14];
+		FAUSTFLOAT* input15 = inputs[15];
+		FAUSTFLOAT* input16 = inputs[16];
+		FAUSTFLOAT* input17 = inputs[17];
+		FAUSTFLOAT* input18 = inputs[18];
+		FAUSTFLOAT* input19 = inputs[19];
+		FAUSTFLOAT* input20 = inputs[20];
+		FAUSTFLOAT* input21 = inputs[21];
+		FAUSTFLOAT* input22 = inputs[22];
+		FAUSTFLOAT* input23 = inputs[23];
+		FAUSTFLOAT* input24 = inputs[24];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.800000012f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.800000012f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.800000012f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.400000006f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.400000006f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.400000006f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.400000006f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.400000006f * float(input8[i])));
+			output9[i] = FAUSTFLOAT((0.114285715f * float(input9[i])));
+			output10[i] = FAUSTFLOAT((0.114285715f * float(input10[i])));
+			output11[i] = FAUSTFLOAT((0.114285715f * float(input11[i])));
+			output12[i] = FAUSTFLOAT((0.114285715f * float(input12[i])));
+			output13[i] = FAUSTFLOAT((0.114285715f * float(input13[i])));
+			output14[i] = FAUSTFLOAT((0.114285715f * float(input14[i])));
+			output15[i] = FAUSTFLOAT((0.114285715f * float(input15[i])));
+			output16[i] = FAUSTFLOAT((0.0142857144f * float(input16[i])));
+			output17[i] = FAUSTFLOAT((0.0142857144f * float(input17[i])));
+			output18[i] = FAUSTFLOAT((0.0142857144f * float(input18[i])));
+			output19[i] = FAUSTFLOAT((0.0142857144f * float(input19[i])));
+			output20[i] = FAUSTFLOAT((0.0142857144f * float(input20[i])));
+			output21[i] = FAUSTFLOAT((0.0142857144f * float(input21[i])));
+			output22[i] = FAUSTFLOAT((0.0142857144f * float(input22[i])));
+			output23[i] = FAUSTFLOAT((0.0142857144f * float(input23[i])));
+			output24[i] = FAUSTFLOAT((0.0142857144f * float(input24[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibInPhase3D5.cpp
+++ b/source/HOAUGens/HOALibInPhase3D5.cpp
@@ -1,0 +1,1465 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibInPhase3D5"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibInPhase3D5");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibInPhase3D5");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 36;
+		
+	}
+	virtual int getNumOutputs() {
+		return 36;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			case 25: {
+				rate = 1;
+				break;
+			}
+			case 26: {
+				rate = 1;
+				break;
+			}
+			case 27: {
+				rate = 1;
+				break;
+			}
+			case 28: {
+				rate = 1;
+				break;
+			}
+			case 29: {
+				rate = 1;
+				break;
+			}
+			case 30: {
+				rate = 1;
+				break;
+			}
+			case 31: {
+				rate = 1;
+				break;
+			}
+			case 32: {
+				rate = 1;
+				break;
+			}
+			case 33: {
+				rate = 1;
+				break;
+			}
+			case 34: {
+				rate = 1;
+				break;
+			}
+			case 35: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			case 25: {
+				rate = 1;
+				break;
+			}
+			case 26: {
+				rate = 1;
+				break;
+			}
+			case 27: {
+				rate = 1;
+				break;
+			}
+			case 28: {
+				rate = 1;
+				break;
+			}
+			case 29: {
+				rate = 1;
+				break;
+			}
+			case 30: {
+				rate = 1;
+				break;
+			}
+			case 31: {
+				rate = 1;
+				break;
+			}
+			case 32: {
+				rate = 1;
+				break;
+			}
+			case 33: {
+				rate = 1;
+				break;
+			}
+			case 34: {
+				rate = 1;
+				break;
+			}
+			case 35: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibInPhase3D5");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* input9 = inputs[9];
+		FAUSTFLOAT* input10 = inputs[10];
+		FAUSTFLOAT* input11 = inputs[11];
+		FAUSTFLOAT* input12 = inputs[12];
+		FAUSTFLOAT* input13 = inputs[13];
+		FAUSTFLOAT* input14 = inputs[14];
+		FAUSTFLOAT* input15 = inputs[15];
+		FAUSTFLOAT* input16 = inputs[16];
+		FAUSTFLOAT* input17 = inputs[17];
+		FAUSTFLOAT* input18 = inputs[18];
+		FAUSTFLOAT* input19 = inputs[19];
+		FAUSTFLOAT* input20 = inputs[20];
+		FAUSTFLOAT* input21 = inputs[21];
+		FAUSTFLOAT* input22 = inputs[22];
+		FAUSTFLOAT* input23 = inputs[23];
+		FAUSTFLOAT* input24 = inputs[24];
+		FAUSTFLOAT* input25 = inputs[25];
+		FAUSTFLOAT* input26 = inputs[26];
+		FAUSTFLOAT* input27 = inputs[27];
+		FAUSTFLOAT* input28 = inputs[28];
+		FAUSTFLOAT* input29 = inputs[29];
+		FAUSTFLOAT* input30 = inputs[30];
+		FAUSTFLOAT* input31 = inputs[31];
+		FAUSTFLOAT* input32 = inputs[32];
+		FAUSTFLOAT* input33 = inputs[33];
+		FAUSTFLOAT* input34 = inputs[34];
+		FAUSTFLOAT* input35 = inputs[35];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		FAUSTFLOAT* output25 = outputs[25];
+		FAUSTFLOAT* output26 = outputs[26];
+		FAUSTFLOAT* output27 = outputs[27];
+		FAUSTFLOAT* output28 = outputs[28];
+		FAUSTFLOAT* output29 = outputs[29];
+		FAUSTFLOAT* output30 = outputs[30];
+		FAUSTFLOAT* output31 = outputs[31];
+		FAUSTFLOAT* output32 = outputs[32];
+		FAUSTFLOAT* output33 = outputs[33];
+		FAUSTFLOAT* output34 = outputs[34];
+		FAUSTFLOAT* output35 = outputs[35];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.833333313f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.833333313f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.833333313f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.476190478f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.476190478f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.476190478f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.476190478f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.476190478f * float(input8[i])));
+			output9[i] = FAUSTFLOAT((0.178571433f * float(input9[i])));
+			output10[i] = FAUSTFLOAT((0.178571433f * float(input10[i])));
+			output11[i] = FAUSTFLOAT((0.178571433f * float(input11[i])));
+			output12[i] = FAUSTFLOAT((0.178571433f * float(input12[i])));
+			output13[i] = FAUSTFLOAT((0.178571433f * float(input13[i])));
+			output14[i] = FAUSTFLOAT((0.178571433f * float(input14[i])));
+			output15[i] = FAUSTFLOAT((0.178571433f * float(input15[i])));
+			output16[i] = FAUSTFLOAT((0.039682541f * float(input16[i])));
+			output17[i] = FAUSTFLOAT((0.039682541f * float(input17[i])));
+			output18[i] = FAUSTFLOAT((0.039682541f * float(input18[i])));
+			output19[i] = FAUSTFLOAT((0.039682541f * float(input19[i])));
+			output20[i] = FAUSTFLOAT((0.039682541f * float(input20[i])));
+			output21[i] = FAUSTFLOAT((0.039682541f * float(input21[i])));
+			output22[i] = FAUSTFLOAT((0.039682541f * float(input22[i])));
+			output23[i] = FAUSTFLOAT((0.039682541f * float(input23[i])));
+			output24[i] = FAUSTFLOAT((0.039682541f * float(input24[i])));
+			output25[i] = FAUSTFLOAT((0.0039682542f * float(input25[i])));
+			output26[i] = FAUSTFLOAT((0.0039682542f * float(input26[i])));
+			output27[i] = FAUSTFLOAT((0.0039682542f * float(input27[i])));
+			output28[i] = FAUSTFLOAT((0.0039682542f * float(input28[i])));
+			output29[i] = FAUSTFLOAT((0.0039682542f * float(input29[i])));
+			output30[i] = FAUSTFLOAT((0.0039682542f * float(input30[i])));
+			output31[i] = FAUSTFLOAT((0.0039682542f * float(input31[i])));
+			output32[i] = FAUSTFLOAT((0.0039682542f * float(input32[i])));
+			output33[i] = FAUSTFLOAT((0.0039682542f * float(input33[i])));
+			output34[i] = FAUSTFLOAT((0.0039682542f * float(input34[i])));
+			output35[i] = FAUSTFLOAT((0.0039682542f * float(input35[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibMaxRe3D1.cpp
+++ b/source/HOAUGens/HOALibMaxRe3D1.cpp
@@ -1,0 +1,1113 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibMaxRe3D1"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibMaxRe3D1");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibMaxRe3D1");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 4;
+		
+	}
+	virtual int getNumOutputs() {
+		return 4;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibMaxRe3D1");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.707106769f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.707106769f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.707106769f * float(input3[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibMaxRe3D2.cpp
+++ b/source/HOAUGens/HOALibMaxRe3D2.cpp
@@ -1,0 +1,1168 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibMaxRe3D2"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibMaxRe3D2");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibMaxRe3D2");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 9;
+		
+	}
+	virtual int getNumOutputs() {
+		return 9;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibMaxRe3D2");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.866025388f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.866025388f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.866025388f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.5f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.5f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.5f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.5f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.5f * float(input8[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibMaxRe3D3.cpp
+++ b/source/HOAUGens/HOALibMaxRe3D3.cpp
@@ -1,0 +1,1245 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibMaxRe3D3"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibMaxRe3D3");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibMaxRe3D3");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 16;
+		
+	}
+	virtual int getNumOutputs() {
+		return 16;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibMaxRe3D3");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* input9 = inputs[9];
+		FAUSTFLOAT* input10 = inputs[10];
+		FAUSTFLOAT* input11 = inputs[11];
+		FAUSTFLOAT* input12 = inputs[12];
+		FAUSTFLOAT* input13 = inputs[13];
+		FAUSTFLOAT* input14 = inputs[14];
+		FAUSTFLOAT* input15 = inputs[15];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.923879504f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.923879504f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.923879504f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.707106769f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.707106769f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.707106769f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.707106769f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.707106769f * float(input8[i])));
+			output9[i] = FAUSTFLOAT((0.382683426f * float(input9[i])));
+			output10[i] = FAUSTFLOAT((0.382683426f * float(input10[i])));
+			output11[i] = FAUSTFLOAT((0.382683426f * float(input11[i])));
+			output12[i] = FAUSTFLOAT((0.382683426f * float(input12[i])));
+			output13[i] = FAUSTFLOAT((0.382683426f * float(input13[i])));
+			output14[i] = FAUSTFLOAT((0.382683426f * float(input14[i])));
+			output15[i] = FAUSTFLOAT((0.382683426f * float(input15[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibMaxRe3D4.cpp
+++ b/source/HOAUGens/HOALibMaxRe3D4.cpp
@@ -1,0 +1,1344 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibMaxRe3D4"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibMaxRe3D4");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibMaxRe3D4");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 25;
+		
+	}
+	virtual int getNumOutputs() {
+		return 25;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibMaxRe3D4");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* input9 = inputs[9];
+		FAUSTFLOAT* input10 = inputs[10];
+		FAUSTFLOAT* input11 = inputs[11];
+		FAUSTFLOAT* input12 = inputs[12];
+		FAUSTFLOAT* input13 = inputs[13];
+		FAUSTFLOAT* input14 = inputs[14];
+		FAUSTFLOAT* input15 = inputs[15];
+		FAUSTFLOAT* input16 = inputs[16];
+		FAUSTFLOAT* input17 = inputs[17];
+		FAUSTFLOAT* input18 = inputs[18];
+		FAUSTFLOAT* input19 = inputs[19];
+		FAUSTFLOAT* input20 = inputs[20];
+		FAUSTFLOAT* input21 = inputs[21];
+		FAUSTFLOAT* input22 = inputs[22];
+		FAUSTFLOAT* input23 = inputs[23];
+		FAUSTFLOAT* input24 = inputs[24];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.95105654f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.95105654f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.95105654f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.809017003f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.809017003f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.809017003f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.809017003f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.809017003f * float(input8[i])));
+			output9[i] = FAUSTFLOAT((0.587785244f * float(input9[i])));
+			output10[i] = FAUSTFLOAT((0.587785244f * float(input10[i])));
+			output11[i] = FAUSTFLOAT((0.587785244f * float(input11[i])));
+			output12[i] = FAUSTFLOAT((0.587785244f * float(input12[i])));
+			output13[i] = FAUSTFLOAT((0.587785244f * float(input13[i])));
+			output14[i] = FAUSTFLOAT((0.587785244f * float(input14[i])));
+			output15[i] = FAUSTFLOAT((0.587785244f * float(input15[i])));
+			output16[i] = FAUSTFLOAT((0.309017003f * float(input16[i])));
+			output17[i] = FAUSTFLOAT((0.309017003f * float(input17[i])));
+			output18[i] = FAUSTFLOAT((0.309017003f * float(input18[i])));
+			output19[i] = FAUSTFLOAT((0.309017003f * float(input19[i])));
+			output20[i] = FAUSTFLOAT((0.309017003f * float(input20[i])));
+			output21[i] = FAUSTFLOAT((0.309017003f * float(input21[i])));
+			output22[i] = FAUSTFLOAT((0.309017003f * float(input22[i])));
+			output23[i] = FAUSTFLOAT((0.309017003f * float(input23[i])));
+			output24[i] = FAUSTFLOAT((0.309017003f * float(input24[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOALibMaxRe3D5.cpp
+++ b/source/HOAUGens/HOALibMaxRe3D5.cpp
@@ -1,0 +1,1465 @@
+/* ------------------------------------------------------------
+author: "Pierre Guillot, Eliott Paris, Julien Colafrancesco"
+copyright: "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8"
+name: "HOALibMaxRe3D5"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "Pierre Guillot, Eliott Paris, Julien Colafrancesco");
+		m->declare("copyright", "2012-2015 Guillot, Paris, Colafrancesco, CICM, Labex Arts H2H, U. Paris 8");
+		m->declare("filename", "HOALibMaxRe3D5");
+		m->declare("math.lib/author", "GRAME");
+		m->declare("math.lib/copyright", "GRAME");
+		m->declare("math.lib/deprecated", "This library is deprecated and is not maintained anymore. It will be removed in August 2017.");
+		m->declare("math.lib/license", "LGPL with exception");
+		m->declare("math.lib/name", "Math Library");
+		m->declare("math.lib/version", "1.0");
+		m->declare("name", "HOALibMaxRe3D5");
+		m->declare("title", "High Order Ambisonics library");
+	}
+
+	virtual int getNumInputs() {
+		return 36;
+		
+	}
+	virtual int getNumOutputs() {
+		return 36;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			case 25: {
+				rate = 1;
+				break;
+			}
+			case 26: {
+				rate = 1;
+				break;
+			}
+			case 27: {
+				rate = 1;
+				break;
+			}
+			case 28: {
+				rate = 1;
+				break;
+			}
+			case 29: {
+				rate = 1;
+				break;
+			}
+			case 30: {
+				rate = 1;
+				break;
+			}
+			case 31: {
+				rate = 1;
+				break;
+			}
+			case 32: {
+				rate = 1;
+				break;
+			}
+			case 33: {
+				rate = 1;
+				break;
+			}
+			case 34: {
+				rate = 1;
+				break;
+			}
+			case 35: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			case 25: {
+				rate = 1;
+				break;
+			}
+			case 26: {
+				rate = 1;
+				break;
+			}
+			case 27: {
+				rate = 1;
+				break;
+			}
+			case 28: {
+				rate = 1;
+				break;
+			}
+			case 29: {
+				rate = 1;
+				break;
+			}
+			case 30: {
+				rate = 1;
+				break;
+			}
+			case 31: {
+				rate = 1;
+				break;
+			}
+			case 32: {
+				rate = 1;
+				break;
+			}
+			case 33: {
+				rate = 1;
+				break;
+			}
+			case 34: {
+				rate = 1;
+				break;
+			}
+			case 35: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		
+	}
+	
+	virtual void instanceClear() {
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOALibMaxRe3D5");
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* input1 = inputs[1];
+		FAUSTFLOAT* input2 = inputs[2];
+		FAUSTFLOAT* input3 = inputs[3];
+		FAUSTFLOAT* input4 = inputs[4];
+		FAUSTFLOAT* input5 = inputs[5];
+		FAUSTFLOAT* input6 = inputs[6];
+		FAUSTFLOAT* input7 = inputs[7];
+		FAUSTFLOAT* input8 = inputs[8];
+		FAUSTFLOAT* input9 = inputs[9];
+		FAUSTFLOAT* input10 = inputs[10];
+		FAUSTFLOAT* input11 = inputs[11];
+		FAUSTFLOAT* input12 = inputs[12];
+		FAUSTFLOAT* input13 = inputs[13];
+		FAUSTFLOAT* input14 = inputs[14];
+		FAUSTFLOAT* input15 = inputs[15];
+		FAUSTFLOAT* input16 = inputs[16];
+		FAUSTFLOAT* input17 = inputs[17];
+		FAUSTFLOAT* input18 = inputs[18];
+		FAUSTFLOAT* input19 = inputs[19];
+		FAUSTFLOAT* input20 = inputs[20];
+		FAUSTFLOAT* input21 = inputs[21];
+		FAUSTFLOAT* input22 = inputs[22];
+		FAUSTFLOAT* input23 = inputs[23];
+		FAUSTFLOAT* input24 = inputs[24];
+		FAUSTFLOAT* input25 = inputs[25];
+		FAUSTFLOAT* input26 = inputs[26];
+		FAUSTFLOAT* input27 = inputs[27];
+		FAUSTFLOAT* input28 = inputs[28];
+		FAUSTFLOAT* input29 = inputs[29];
+		FAUSTFLOAT* input30 = inputs[30];
+		FAUSTFLOAT* input31 = inputs[31];
+		FAUSTFLOAT* input32 = inputs[32];
+		FAUSTFLOAT* input33 = inputs[33];
+		FAUSTFLOAT* input34 = inputs[34];
+		FAUSTFLOAT* input35 = inputs[35];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		FAUSTFLOAT* output25 = outputs[25];
+		FAUSTFLOAT* output26 = outputs[26];
+		FAUSTFLOAT* output27 = outputs[27];
+		FAUSTFLOAT* output28 = outputs[28];
+		FAUSTFLOAT* output29 = outputs[29];
+		FAUSTFLOAT* output30 = outputs[30];
+		FAUSTFLOAT* output31 = outputs[31];
+		FAUSTFLOAT* output32 = outputs[32];
+		FAUSTFLOAT* output33 = outputs[33];
+		FAUSTFLOAT* output34 = outputs[34];
+		FAUSTFLOAT* output35 = outputs[35];
+		for (int i = 0; (i < count); i = (i + 1)) {
+			output0[i] = FAUSTFLOAT(float(input0[i]));
+			output1[i] = FAUSTFLOAT((0.965925813f * float(input1[i])));
+			output2[i] = FAUSTFLOAT((0.965925813f * float(input2[i])));
+			output3[i] = FAUSTFLOAT((0.965925813f * float(input3[i])));
+			output4[i] = FAUSTFLOAT((0.866025388f * float(input4[i])));
+			output5[i] = FAUSTFLOAT((0.866025388f * float(input5[i])));
+			output6[i] = FAUSTFLOAT((0.866025388f * float(input6[i])));
+			output7[i] = FAUSTFLOAT((0.866025388f * float(input7[i])));
+			output8[i] = FAUSTFLOAT((0.866025388f * float(input8[i])));
+			output9[i] = FAUSTFLOAT((0.707106769f * float(input9[i])));
+			output10[i] = FAUSTFLOAT((0.707106769f * float(input10[i])));
+			output11[i] = FAUSTFLOAT((0.707106769f * float(input11[i])));
+			output12[i] = FAUSTFLOAT((0.707106769f * float(input12[i])));
+			output13[i] = FAUSTFLOAT((0.707106769f * float(input13[i])));
+			output14[i] = FAUSTFLOAT((0.707106769f * float(input14[i])));
+			output15[i] = FAUSTFLOAT((0.707106769f * float(input15[i])));
+			output16[i] = FAUSTFLOAT((0.5f * float(input16[i])));
+			output17[i] = FAUSTFLOAT((0.5f * float(input17[i])));
+			output18[i] = FAUSTFLOAT((0.5f * float(input18[i])));
+			output19[i] = FAUSTFLOAT((0.5f * float(input19[i])));
+			output20[i] = FAUSTFLOAT((0.5f * float(input20[i])));
+			output21[i] = FAUSTFLOAT((0.5f * float(input21[i])));
+			output22[i] = FAUSTFLOAT((0.5f * float(input22[i])));
+			output23[i] = FAUSTFLOAT((0.5f * float(input23[i])));
+			output24[i] = FAUSTFLOAT((0.5f * float(input24[i])));
+			output25[i] = FAUSTFLOAT((0.258819044f * float(input25[i])));
+			output26[i] = FAUSTFLOAT((0.258819044f * float(input26[i])));
+			output27[i] = FAUSTFLOAT((0.258819044f * float(input27[i])));
+			output28[i] = FAUSTFLOAT((0.258819044f * float(input28[i])));
+			output29[i] = FAUSTFLOAT((0.258819044f * float(input29[i])));
+			output30[i] = FAUSTFLOAT((0.258819044f * float(input30[i])));
+			output31[i] = FAUSTFLOAT((0.258819044f * float(input31[i])));
+			output32[i] = FAUSTFLOAT((0.258819044f * float(input32[i])));
+			output33[i] = FAUSTFLOAT((0.258819044f * float(input33[i])));
+			output34[i] = FAUSTFLOAT((0.258819044f * float(input34[i])));
+			output35[i] = FAUSTFLOAT((0.258819044f * float(input35[i])));
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOAmbiPanner1.cpp
+++ b/source/HOAUGens/HOAmbiPanner1.cpp
@@ -1,0 +1,1123 @@
+/* ------------------------------------------------------------
+author: "AmbisonicDecoderToolkit"
+copyright: "(c) Aaron J. Heller 2013", "(c) Florian Grond 2015"
+license: "GPL"
+name: "HOAmbiPanner1"
+version: "1.0"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	float fRec0[2];
+	FAUSTFLOAT fHslider1;
+	float fRec1[2];
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "AmbisonicDecoderToolkit");
+		m->declare("copyright", "(c) Aaron J. Heller 2013");
+		m->declare("filename", "HOAmbiPanner1");
+		m->declare("license", "GPL");
+		m->declare("name", "HOAmbiPanner1");
+		m->declare("version", "1.0");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 4;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
+			fRec0[l0] = 0.0f;
+			
+		}
+		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
+			fRec1[l1] = 0.0f;
+			
+		}
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOAmbiPanner1");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		float fSlow0 = (0.00100000005f * float(fHslider0));
+		float fSlow1 = (0.00100000005f * float(fHslider1));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
+			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
+			float fTemp1 = cosf(fRec1[0]);
+			output1[i] = FAUSTFLOAT(((sinf(fRec0[0]) * fTemp1) * fTemp0));
+			output2[i] = FAUSTFLOAT((sinf(fRec1[0]) * fTemp0));
+			output3[i] = FAUSTFLOAT(((fTemp1 * cosf(fRec0[0])) * fTemp0));
+			fRec0[1] = fRec0[0];
+			fRec1[1] = fRec1[0];
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOAmbiPanner2.cpp
+++ b/source/HOAUGens/HOAmbiPanner2.cpp
@@ -1,0 +1,1162 @@
+/* ------------------------------------------------------------
+author: "AmbisonicDecoderToolkit"
+copyright: "(c) Aaron J. Heller 2013", "(c) Florian Grond 2015"
+license: "GPL"
+name: "HOAmbiPanner2"
+version: "1.0"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	float fRec0[2];
+	FAUSTFLOAT fHslider1;
+	float fRec1[2];
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "AmbisonicDecoderToolkit");
+		m->declare("copyright", "(c) Aaron J. Heller 2013");
+		m->declare("filename", "HOAmbiPanner2");
+		m->declare("license", "GPL");
+		m->declare("name", "HOAmbiPanner2");
+		m->declare("version", "1.0");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 9;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
+			fRec0[l0] = 0.0f;
+			
+		}
+		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
+			fRec1[l1] = 0.0f;
+			
+		}
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOAmbiPanner2");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		float fSlow0 = (0.00100000005f * float(fHslider0));
+		float fSlow1 = (0.00100000005f * float(fHslider1));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
+			float fTemp1 = sinf(fRec0[0]);
+			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
+			float fTemp2 = cosf(fRec1[0]);
+			float fTemp3 = (fTemp1 * fTemp2);
+			output1[i] = FAUSTFLOAT((fTemp3 * fTemp0));
+			float fTemp4 = sinf(fRec1[0]);
+			output2[i] = FAUSTFLOAT((fTemp4 * fTemp0));
+			float fTemp5 = cosf(fRec0[0]);
+			float fTemp6 = (fTemp2 * fTemp5);
+			output3[i] = FAUSTFLOAT((fTemp6 * fTemp0));
+			output4[i] = FAUSTFLOAT((1.73205078f * (((fTemp1 * mydsp_faustpower2_f(fTemp2)) * fTemp5) * fTemp0)));
+			output5[i] = FAUSTFLOAT((1.73205078f * ((fTemp3 * fTemp4) * fTemp0)));
+			output6[i] = FAUSTFLOAT((0.5f * (((3.0f * mydsp_faustpower2_f(fTemp4)) + -1.0f) * fTemp0)));
+			output7[i] = FAUSTFLOAT((1.73205078f * (((fTemp2 * fTemp4) * fTemp5) * fTemp0)));
+			output8[i] = FAUSTFLOAT((0.866025388f * ((mydsp_faustpower2_f(fTemp6) - mydsp_faustpower2_f(fTemp3)) * fTemp0)));
+			fRec0[1] = fRec0[0];
+			fRec1[1] = fRec1[0];
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOAmbiPanner3.cpp
+++ b/source/HOAUGens/HOAmbiPanner3.cpp
@@ -1,0 +1,1211 @@
+/* ------------------------------------------------------------
+author: "AmbisonicDecoderToolkit"
+copyright: "(c) Aaron J. Heller 2013", "(c) Florian Grond 2015"
+license: "GPL"
+name: "HOAmbiPanner3"
+version: "1.0"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	float fRec0[2];
+	FAUSTFLOAT fHslider1;
+	float fRec1[2];
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "AmbisonicDecoderToolkit");
+		m->declare("copyright", "(c) Aaron J. Heller 2013");
+		m->declare("filename", "HOAmbiPanner3");
+		m->declare("license", "GPL");
+		m->declare("name", "HOAmbiPanner3");
+		m->declare("version", "1.0");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 16;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
+			fRec0[l0] = 0.0f;
+			
+		}
+		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
+			fRec1[l1] = 0.0f;
+			
+		}
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOAmbiPanner3");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		float fSlow0 = (0.00100000005f * float(fHslider0));
+		float fSlow1 = (0.00100000005f * float(fHslider1));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
+			float fTemp1 = sinf(fRec0[0]);
+			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
+			float fTemp2 = cosf(fRec1[0]);
+			float fTemp3 = (fTemp1 * fTemp2);
+			output1[i] = FAUSTFLOAT((fTemp3 * fTemp0));
+			float fTemp4 = sinf(fRec1[0]);
+			output2[i] = FAUSTFLOAT((fTemp4 * fTemp0));
+			float fTemp5 = cosf(fRec0[0]);
+			float fTemp6 = (fTemp2 * fTemp5);
+			output3[i] = FAUSTFLOAT((fTemp6 * fTemp0));
+			float fTemp7 = (fTemp1 * mydsp_faustpower2_f(fTemp2));
+			output4[i] = FAUSTFLOAT((1.73205078f * ((fTemp7 * fTemp5) * fTemp0)));
+			output5[i] = FAUSTFLOAT((1.73205078f * ((fTemp3 * fTemp4) * fTemp0)));
+			float fTemp8 = mydsp_faustpower2_f(fTemp4);
+			output6[i] = FAUSTFLOAT((0.5f * (((3.0f * fTemp8) + -1.0f) * fTemp0)));
+			output7[i] = FAUSTFLOAT((1.73205078f * (((fTemp2 * fTemp4) * fTemp5) * fTemp0)));
+			float fTemp9 = mydsp_faustpower2_f(fTemp6);
+			float fTemp10 = mydsp_faustpower2_f(fTemp3);
+			float fTemp11 = (fTemp9 - fTemp10);
+			output8[i] = FAUSTFLOAT((0.866025388f * (fTemp11 * fTemp0)));
+			output9[i] = FAUSTFLOAT((0.790569425f * ((fTemp3 * ((3.0f * fTemp9) - fTemp10)) * fTemp0)));
+			output10[i] = FAUSTFLOAT((3.87298346f * (((fTemp7 * fTemp4) * fTemp5) * fTemp0)));
+			float fTemp12 = (5.0f * fTemp8);
+			float fTemp13 = (fTemp12 + -1.0f);
+			output11[i] = FAUSTFLOAT((0.612372458f * ((fTemp3 * fTemp13) * fTemp0)));
+			output12[i] = FAUSTFLOAT((0.5f * ((fTemp4 * (fTemp12 + -3.0f)) * fTemp0)));
+			output13[i] = FAUSTFLOAT((0.612372458f * ((fTemp6 * fTemp13) * fTemp0)));
+			output14[i] = FAUSTFLOAT((1.93649173f * ((fTemp4 * fTemp11) * fTemp0)));
+			output15[i] = FAUSTFLOAT((0.790569425f * ((fTemp6 * (fTemp9 - (3.0f * fTemp10))) * fTemp0)));
+			fRec0[1] = fRec0[0];
+			fRec1[1] = fRec1[0];
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOAmbiPanner4.cpp
+++ b/source/HOAUGens/HOAmbiPanner4.cpp
@@ -1,0 +1,1277 @@
+/* ------------------------------------------------------------
+author: "AmbisonicDecoderToolkit"
+copyright: "(c) Aaron J. Heller 2013", "(c) Florian Grond 2015"
+license: "GPL"
+name: "HOAmbiPanner4"
+version: "1.0"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+float mydsp_faustpower4_f(float value) {
+	return (((value * value) * value) * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	float fRec0[2];
+	FAUSTFLOAT fHslider1;
+	float fRec1[2];
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "AmbisonicDecoderToolkit");
+		m->declare("copyright", "(c) Aaron J. Heller 2013");
+		m->declare("filename", "HOAmbiPanner4");
+		m->declare("license", "GPL");
+		m->declare("name", "HOAmbiPanner4");
+		m->declare("version", "1.0");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 25;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
+			fRec0[l0] = 0.0f;
+			
+		}
+		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
+			fRec1[l1] = 0.0f;
+			
+		}
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOAmbiPanner4");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		float fSlow0 = (0.00100000005f * float(fHslider0));
+		float fSlow1 = (0.00100000005f * float(fHslider1));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
+			float fTemp1 = sinf(fRec0[0]);
+			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
+			float fTemp2 = cosf(fRec1[0]);
+			float fTemp3 = (fTemp1 * fTemp2);
+			output1[i] = FAUSTFLOAT((fTemp3 * fTemp0));
+			float fTemp4 = sinf(fRec1[0]);
+			output2[i] = FAUSTFLOAT((fTemp4 * fTemp0));
+			float fTemp5 = cosf(fRec0[0]);
+			float fTemp6 = (fTemp2 * fTemp5);
+			output3[i] = FAUSTFLOAT((fTemp6 * fTemp0));
+			float fTemp7 = (fTemp1 * mydsp_faustpower2_f(fTemp2));
+			float fTemp8 = (fTemp7 * fTemp5);
+			output4[i] = FAUSTFLOAT((1.73205078f * (fTemp8 * fTemp0)));
+			float fTemp9 = (fTemp3 * fTemp4);
+			output5[i] = FAUSTFLOAT((1.73205078f * (fTemp9 * fTemp0)));
+			float fTemp10 = mydsp_faustpower2_f(fTemp4);
+			output6[i] = FAUSTFLOAT((0.5f * (((3.0f * fTemp10) + -1.0f) * fTemp0)));
+			float fTemp11 = ((fTemp2 * fTemp4) * fTemp5);
+			output7[i] = FAUSTFLOAT((1.73205078f * (fTemp11 * fTemp0)));
+			float fTemp12 = mydsp_faustpower2_f(fTemp6);
+			float fTemp13 = mydsp_faustpower2_f(fTemp3);
+			float fTemp14 = (fTemp12 - fTemp13);
+			output8[i] = FAUSTFLOAT((0.866025388f * (fTemp14 * fTemp0)));
+			float fTemp15 = ((3.0f * fTemp12) - fTemp13);
+			output9[i] = FAUSTFLOAT((0.790569425f * ((fTemp3 * fTemp15) * fTemp0)));
+			output10[i] = FAUSTFLOAT((3.87298346f * (((fTemp7 * fTemp4) * fTemp5) * fTemp0)));
+			float fTemp16 = (5.0f * fTemp10);
+			float fTemp17 = (fTemp16 + -1.0f);
+			output11[i] = FAUSTFLOAT((0.612372458f * ((fTemp3 * fTemp17) * fTemp0)));
+			output12[i] = FAUSTFLOAT((0.5f * ((fTemp4 * (fTemp16 + -3.0f)) * fTemp0)));
+			output13[i] = FAUSTFLOAT((0.612372458f * ((fTemp6 * fTemp17) * fTemp0)));
+			output14[i] = FAUSTFLOAT((1.93649173f * ((fTemp4 * fTemp14) * fTemp0)));
+			float fTemp18 = (fTemp12 - (3.0f * fTemp13));
+			output15[i] = FAUSTFLOAT((0.790569425f * ((fTemp6 * fTemp18) * fTemp0)));
+			output16[i] = FAUSTFLOAT((2.95804f * ((fTemp8 * fTemp14) * fTemp0)));
+			output17[i] = FAUSTFLOAT((2.09165001f * ((fTemp9 * fTemp15) * fTemp0)));
+			float fTemp19 = (7.0f * fTemp10);
+			float fTemp20 = (fTemp19 + -1.0f);
+			output18[i] = FAUSTFLOAT((1.11803401f * ((fTemp8 * fTemp20) * fTemp0)));
+			float fTemp21 = (fTemp19 + -3.0f);
+			output19[i] = FAUSTFLOAT((0.790569425f * ((fTemp9 * fTemp21) * fTemp0)));
+			output20[i] = FAUSTFLOAT((0.125f * (((fTemp10 * ((35.0f * fTemp10) + -30.0f)) + 3.0f) * fTemp0)));
+			output21[i] = FAUSTFLOAT((0.790569425f * ((fTemp11 * fTemp21) * fTemp0)));
+			output22[i] = FAUSTFLOAT((0.559017003f * ((fTemp14 * fTemp20) * fTemp0)));
+			output23[i] = FAUSTFLOAT((2.09165001f * ((fTemp11 * fTemp18) * fTemp0)));
+			output24[i] = FAUSTFLOAT((0.73951f * (((fTemp12 * (fTemp12 - (6.0f * fTemp13))) + mydsp_faustpower4_f(fTemp3)) * fTemp0)));
+			fRec0[1] = fRec0[0];
+			fRec1[1] = fRec1[0];
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/HOAmbiPanner5.cpp
+++ b/source/HOAUGens/HOAmbiPanner5.cpp
@@ -1,0 +1,1354 @@
+/* ------------------------------------------------------------
+author: "AmbisonicDecoderToolkit"
+copyright: "(c) Aaron J. Heller 2013", "(c) Florian Grond 2015"
+license: "GPL"
+name: "HOAmbiPanner5"
+version: "1.0"
+Code generated with Faust 2.5.23 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+//-------------------------------------------------------------------
+// FAUST architecture file for SuperCollider.
+// Copyright (C) 2005-2012 Stefan Kersten.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+// 02111-1307 USA
+//-------------------------------------------------------------------
+
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
+#if !defined(SC_FAUST_PREFIX)
+#define SC_FAUST_PREFIX ""
+#endif
+
+#include <map>
+#include <string>
+#include <string.h>
+#include <SC_PlugIn.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __dsp__
+#define __dsp__
+
+#include <string>
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+class UI;
+struct Meta;
+
+/**
+ * DSP memory manager.
+ */
+
+struct dsp_memory_manager {
+    
+    virtual ~dsp_memory_manager() {}
+    
+    virtual void* allocate(size_t size) = 0;
+    virtual void destroy(void* ptr) = 0;
+    
+};
+
+/**
+* Signal processor definition.
+*/
+
+class dsp {
+
+    public:
+
+        dsp() {}
+        virtual ~dsp() {}
+
+        /* Return instance number of audio inputs */
+        virtual int getNumInputs() = 0;
+    
+        /* Return instance number of audio outputs */
+        virtual int getNumOutputs() = 0;
+    
+        /**
+         * Trigger the ui_interface parameter with instance specific calls
+         * to 'addBtton', 'addVerticalSlider'... in order to build the UI.
+         *
+         * @param ui_interface - the user interface builder
+         */
+        virtual void buildUserInterface(UI* ui_interface) = 0;
+    
+        /* Returns the sample rate currently used by the instance */
+        virtual int getSampleRate() = 0;
+    
+        /**
+         * Global init, calls the following methods:
+         * - static class 'classInit': static tables initialization
+         * - 'instanceInit': constants and instance state initialization
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void init(int samplingRate) = 0;
+
+        /**
+         * Init instance state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceInit(int samplingRate) = 0;
+
+        /**
+         * Init instance constant state
+         *
+         * @param samplingRate - the sampling rate in Hertz
+         */
+        virtual void instanceConstants(int samplingRate) = 0;
+    
+        /* Init default control parameters values */
+        virtual void instanceResetUserInterface() = 0;
+    
+        /* Init instance state (delay lines...) */
+        virtual void instanceClear() = 0;
+ 
+        /**
+         * Return a clone of the instance.
+         *
+         * @return a copy of the instance on success, otherwise a null pointer.
+         */
+        virtual dsp* clone() = 0;
+    
+        /**
+         * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
+         *
+         * @param m - the Meta* meta user
+         */
+        virtual void metadata(Meta* m) = 0;
+    
+        /**
+         * DSP instance computation, to be called with successive in/out audio buffers.
+         *
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+    
+        /**
+         * DSP instance computation: alternative method to be used by subclasses.
+         *
+         * @param date_usec - the timestamp in microsec given by audio driver.
+         * @param count - the number of frames to compute
+         * @param inputs - the input audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
+         *
+         */
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+       
+};
+
+/**
+ * Generic DSP decorator.
+ */
+
+class decorator_dsp : public dsp {
+
+    protected:
+
+        dsp* fDSP;
+
+    public:
+
+        decorator_dsp(dsp* dsp = 0):fDSP(dsp) {}
+        virtual ~decorator_dsp() { delete fDSP; }
+
+        virtual int getNumInputs() { return fDSP->getNumInputs(); }
+        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
+        virtual int getSampleRate() { return fDSP->getSampleRate(); }
+        virtual void init(int samplingRate) { fDSP->init(samplingRate); }
+        virtual void instanceInit(int samplingRate) { fDSP->instanceInit(samplingRate); }
+        virtual void instanceConstants(int samplingRate) { fDSP->instanceConstants(samplingRate); }
+        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+        virtual void instanceClear() { fDSP->instanceClear(); }
+        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+        virtual void metadata(Meta* m) { fDSP->metadata(m); }
+        // Beware: subclasses usually have to overload the two 'compute' methods
+        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+    
+};
+
+/**
+ * DSP factory class.
+ */
+
+class dsp_factory {
+    
+    protected:
+    
+        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+        virtual ~dsp_factory() {}
+    
+    public:
+    
+        virtual std::string getName() = 0;
+        virtual std::string getSHAKey() = 0;
+        virtual std::string getDSPCode() = 0;
+    
+        virtual dsp* createDSPInstance() = 0;
+    
+        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+        virtual dsp_memory_manager* getMemoryManager() = 0;
+    
+};
+
+/**
+ * On Intel set FZ (Flush to Zero) and DAZ (Denormals Are Zero)
+ * flags to avoid costly denormals.
+ */
+
+#ifdef __SSE__
+    #include <xmmintrin.h>
+    #ifdef __SSE2__
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
+    #else
+        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+    #endif
+#else
+    #define AVOIDDENORMALS
+#endif
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __UI_H__
+#define __UI_H__
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+/*******************************************************************************
+ * UI : Faust DSP User Interface
+ * User Interface as expected by the buildUserInterface() method of a DSP.
+ * This abstract class contains only the method that the Faust compiler can
+ * generate to describe a DSP user interface.
+ ******************************************************************************/
+
+struct Soundfile;
+
+class UI
+{
+
+    public:
+
+        UI() {}
+
+        virtual ~UI() {}
+
+        // -- widget's layouts
+
+        virtual void openTabBox(const char* label) = 0;
+        virtual void openHorizontalBox(const char* label) = 0;
+        virtual void openVerticalBox(const char* label) = 0;
+        virtual void closeBox() = 0;
+
+        // -- active widgets
+
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) = 0;
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step) = 0;
+
+        // -- passive widgets
+
+        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) = 0;
+    
+        // -- soundfiles
+    
+        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
+
+        // -- metadata declarations
+
+        virtual void declare(FAUSTFLOAT*, const char*, const char*) {}
+};
+
+#endif
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+ 
+#ifndef __misc__
+#define __misc__
+
+#include <algorithm>
+#include <map>
+#include <string.h>
+#include <stdlib.h>
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2017 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __meta__
+#define __meta__
+
+struct Meta
+{
+    virtual void declare(const char* key, const char* value) = 0;
+    virtual ~Meta() {};
+};
+
+#endif
+
+using std::max;
+using std::min;
+
+struct XXXX_Meta : std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+struct MY_Meta : Meta, std::map<const char*, const char*>
+{
+    void declare(const char* key, const char* value) { (*this)[key]=value; }
+};
+
+inline int lsr(int x, int n)	{ return int(((unsigned int)x) >> n); }
+
+inline int int2pow2(int x)		{ int r = 0; while ((1<<r) < x) r++; return r; }
+
+inline long lopt(char* argv[], const char* name, long def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return atoi(argv[i+1]);
+	return def;
+}
+
+inline bool isopt(char* argv[], const char* name)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return true;
+	return false;
+}
+
+inline const char* lopts(char* argv[], const char* name, const char* def)
+{
+	int	i;
+	for (i = 0; argv[i]; i++) if (!strcmp(argv[i], name)) return argv[i+1];
+	return def;
+}
+
+#endif
+
+
+using namespace std;
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+    #define FAUST_EXPORT __attribute__((visibility("default")))
+#else
+    #define FAUST_EXPORT  SC_API_EXPORT
+#endif
+
+#ifdef WIN32
+    #define STRDUP _strdup
+#else
+    #define STRDUP strdup
+#endif
+
+//----------------------------------------------------------------------------
+// Vector intrinsics
+//----------------------------------------------------------------------------
+
+
+//----------------------------------------------------------------------------
+// Metadata
+//----------------------------------------------------------------------------
+
+class MetaData : public Meta
+               , public std::map<std::string, std::string>
+{
+public:
+    void declare(const char* key, const char* value)
+    {
+        (*this)[key] = value;
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control counter
+//----------------------------------------------------------------------------
+
+class ControlCounter : public UI
+{
+public:
+    ControlCounter()
+        : mNumControlInputs(0),
+          mNumControlOutputs(0)
+    {}
+
+    size_t getNumControls() const { return getNumControlInputs(); }
+    size_t getNumControlInputs() const { return mNumControlInputs; }
+    size_t getNumControlOutputs() const { return mNumControlOutputs; }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addControlInput(); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addControlInput(); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
+    { addControlOutput(); }
+    
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+protected:
+    void addControlInput() { mNumControlInputs++; }
+    void addControlOutput() { mNumControlOutputs++; }
+
+private:
+    size_t mNumControlInputs;
+    size_t mNumControlOutputs;
+};
+
+//----------------------------------------------------------------------------
+// UI control
+//----------------------------------------------------------------------------
+
+struct Control
+{
+    typedef void (*UpdateFunction)(Control* self, FAUSTFLOAT value);
+
+    UpdateFunction updateFunction;
+    FAUSTFLOAT* zone;
+    FAUSTFLOAT min, max;
+
+    inline void update(FAUSTFLOAT value)
+    {
+        (*updateFunction)(this, value);
+    }
+
+    static void simpleUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = value;
+    }
+    static void boundedUpdate(Control* self, FAUSTFLOAT value)
+    {
+        *self->zone = sc_clip(value, self->min, self->max);
+    }
+};
+
+//----------------------------------------------------------------------------
+// Control allocator
+//----------------------------------------------------------------------------
+
+class ControlAllocator : public UI
+{
+public:
+    ControlAllocator(Control* controls)
+        : mControls(controls)
+    { }
+
+    // Layout widgets
+    virtual void openTabBox(const char* label) { }
+    virtual void openHorizontalBox(const char* label) { }
+    virtual void openVerticalBox(const char* label) { }
+    virtual void closeBox() { }
+
+    // Active widgets
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    { addSimpleControl(zone); }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    { addBoundedControl(zone, min, max, step); }
+
+    // Passive widgets
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max) {}
+    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
+
+private:
+    void addControl(Control::UpdateFunction updateFunction, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT /* step */)
+    {
+        Control* ctrl        = mControls++;
+        ctrl->updateFunction = updateFunction;
+        ctrl->zone           = zone;
+        ctrl->min            = min;
+        ctrl->max            = max;
+    }
+    void addSimpleControl(FAUSTFLOAT* zone)
+    {
+        addControl(Control::simpleUpdate, zone, 0.f, 0.f, 0.f);
+    }
+    void addBoundedControl(FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addControl(Control::boundedUpdate, zone, min, max, step);
+    }
+
+private:
+    Control* mControls;
+};
+
+//----------------------------------------------------------------------------
+// FAUST generated code
+//----------------------------------------------------------------------------
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+
+float mydsp_faustpower2_f(float value) {
+	return (value * value);
+	
+}
+float mydsp_faustpower4_f(float value) {
+	return (((value * value) * value) * value);
+	
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp : public dsp {
+	
+ private:
+	
+	FAUSTFLOAT fHslider0;
+	float fRec0[2];
+	FAUSTFLOAT fHslider1;
+	float fRec1[2];
+	int fSamplingFreq;
+	
+ public:
+	
+	void metadata(Meta* m) { 
+		m->declare("author", "AmbisonicDecoderToolkit");
+		m->declare("copyright", "(c) Aaron J. Heller 2013");
+		m->declare("filename", "HOAmbiPanner5");
+		m->declare("license", "GPL");
+		m->declare("name", "HOAmbiPanner5");
+		m->declare("version", "1.0");
+	}
+
+	virtual int getNumInputs() {
+		return 1;
+		
+	}
+	virtual int getNumOutputs() {
+		return 36;
+		
+	}
+	virtual int getInputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	virtual int getOutputRate(int channel) {
+		int rate;
+		switch (channel) {
+			case 0: {
+				rate = 1;
+				break;
+			}
+			case 1: {
+				rate = 1;
+				break;
+			}
+			case 2: {
+				rate = 1;
+				break;
+			}
+			case 3: {
+				rate = 1;
+				break;
+			}
+			case 4: {
+				rate = 1;
+				break;
+			}
+			case 5: {
+				rate = 1;
+				break;
+			}
+			case 6: {
+				rate = 1;
+				break;
+			}
+			case 7: {
+				rate = 1;
+				break;
+			}
+			case 8: {
+				rate = 1;
+				break;
+			}
+			case 9: {
+				rate = 1;
+				break;
+			}
+			case 10: {
+				rate = 1;
+				break;
+			}
+			case 11: {
+				rate = 1;
+				break;
+			}
+			case 12: {
+				rate = 1;
+				break;
+			}
+			case 13: {
+				rate = 1;
+				break;
+			}
+			case 14: {
+				rate = 1;
+				break;
+			}
+			case 15: {
+				rate = 1;
+				break;
+			}
+			case 16: {
+				rate = 1;
+				break;
+			}
+			case 17: {
+				rate = 1;
+				break;
+			}
+			case 18: {
+				rate = 1;
+				break;
+			}
+			case 19: {
+				rate = 1;
+				break;
+			}
+			case 20: {
+				rate = 1;
+				break;
+			}
+			case 21: {
+				rate = 1;
+				break;
+			}
+			case 22: {
+				rate = 1;
+				break;
+			}
+			case 23: {
+				rate = 1;
+				break;
+			}
+			case 24: {
+				rate = 1;
+				break;
+			}
+			case 25: {
+				rate = 1;
+				break;
+			}
+			case 26: {
+				rate = 1;
+				break;
+			}
+			case 27: {
+				rate = 1;
+				break;
+			}
+			case 28: {
+				rate = 1;
+				break;
+			}
+			case 29: {
+				rate = 1;
+				break;
+			}
+			case 30: {
+				rate = 1;
+				break;
+			}
+			case 31: {
+				rate = 1;
+				break;
+			}
+			case 32: {
+				rate = 1;
+				break;
+			}
+			case 33: {
+				rate = 1;
+				break;
+			}
+			case 34: {
+				rate = 1;
+				break;
+			}
+			case 35: {
+				rate = 1;
+				break;
+			}
+			default: {
+				rate = -1;
+				break;
+			}
+			
+		}
+		return rate;
+		
+	}
+	
+	static void classInit(int samplingFreq) {
+		
+	}
+	
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
+	}
+	
+	virtual void instanceResetUserInterface() {
+		fHslider0 = FAUSTFLOAT(0.0f);
+		fHslider1 = FAUSTFLOAT(0.0f);
+		
+	}
+	
+	virtual void instanceClear() {
+		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
+			fRec0[l0] = 0.0f;
+			
+		}
+		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
+			fRec1[l1] = 0.0f;
+			
+		}
+		
+	}
+	
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
+	}
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceResetUserInterface();
+		instanceClear();
+	}
+	
+	virtual mydsp* clone() {
+		return new mydsp();
+	}
+	virtual int getSampleRate() {
+		return fSamplingFreq;
+		
+	}
+	
+	virtual void buildUserInterface(UI* ui_interface) {
+		ui_interface->openVerticalBox("HOAmbiPanner5");
+		ui_interface->declare(&fHslider0, "1", "");
+		ui_interface->declare(&fHslider0, "unit", "rad");
+		ui_interface->addHorizontalSlider("azi", &fHslider0, 0.0f, -3.14159274f, 3.14159274f, 1.00000001e-07f);
+		ui_interface->declare(&fHslider1, "2", "");
+		ui_interface->declare(&fHslider1, "unit", "rad");
+		ui_interface->addHorizontalSlider("ele", &fHslider1, 0.0f, -1.57079637f, 1.57079637f, 1.00000001e-07f);
+		ui_interface->closeBox();
+		
+	}
+	
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		FAUSTFLOAT* output1 = outputs[1];
+		FAUSTFLOAT* output2 = outputs[2];
+		FAUSTFLOAT* output3 = outputs[3];
+		FAUSTFLOAT* output4 = outputs[4];
+		FAUSTFLOAT* output5 = outputs[5];
+		FAUSTFLOAT* output6 = outputs[6];
+		FAUSTFLOAT* output7 = outputs[7];
+		FAUSTFLOAT* output8 = outputs[8];
+		FAUSTFLOAT* output9 = outputs[9];
+		FAUSTFLOAT* output10 = outputs[10];
+		FAUSTFLOAT* output11 = outputs[11];
+		FAUSTFLOAT* output12 = outputs[12];
+		FAUSTFLOAT* output13 = outputs[13];
+		FAUSTFLOAT* output14 = outputs[14];
+		FAUSTFLOAT* output15 = outputs[15];
+		FAUSTFLOAT* output16 = outputs[16];
+		FAUSTFLOAT* output17 = outputs[17];
+		FAUSTFLOAT* output18 = outputs[18];
+		FAUSTFLOAT* output19 = outputs[19];
+		FAUSTFLOAT* output20 = outputs[20];
+		FAUSTFLOAT* output21 = outputs[21];
+		FAUSTFLOAT* output22 = outputs[22];
+		FAUSTFLOAT* output23 = outputs[23];
+		FAUSTFLOAT* output24 = outputs[24];
+		FAUSTFLOAT* output25 = outputs[25];
+		FAUSTFLOAT* output26 = outputs[26];
+		FAUSTFLOAT* output27 = outputs[27];
+		FAUSTFLOAT* output28 = outputs[28];
+		FAUSTFLOAT* output29 = outputs[29];
+		FAUSTFLOAT* output30 = outputs[30];
+		FAUSTFLOAT* output31 = outputs[31];
+		FAUSTFLOAT* output32 = outputs[32];
+		FAUSTFLOAT* output33 = outputs[33];
+		FAUSTFLOAT* output34 = outputs[34];
+		FAUSTFLOAT* output35 = outputs[35];
+		float fSlow0 = (0.00100000005f * float(fHslider0));
+		float fSlow1 = (0.00100000005f * float(fHslider1));
+		for (int i = 0; (i < count); i = (i + 1)) {
+			float fTemp0 = float(input0[i]);
+			output0[i] = FAUSTFLOAT(fTemp0);
+			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
+			float fTemp1 = sinf(fRec0[0]);
+			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
+			float fTemp2 = cosf(fRec1[0]);
+			float fTemp3 = (fTemp1 * fTemp2);
+			output1[i] = FAUSTFLOAT((fTemp3 * fTemp0));
+			float fTemp4 = sinf(fRec1[0]);
+			output2[i] = FAUSTFLOAT((fTemp4 * fTemp0));
+			float fTemp5 = cosf(fRec0[0]);
+			float fTemp6 = (fTemp2 * fTemp5);
+			output3[i] = FAUSTFLOAT((fTemp6 * fTemp0));
+			float fTemp7 = (fTemp1 * mydsp_faustpower2_f(fTemp2));
+			float fTemp8 = (fTemp7 * fTemp5);
+			output4[i] = FAUSTFLOAT((1.73205078f * (fTemp8 * fTemp0)));
+			float fTemp9 = (fTemp3 * fTemp4);
+			output5[i] = FAUSTFLOAT((1.73205078f * (fTemp9 * fTemp0)));
+			float fTemp10 = mydsp_faustpower2_f(fTemp4);
+			output6[i] = FAUSTFLOAT((0.5f * (((3.0f * fTemp10) + -1.0f) * fTemp0)));
+			float fTemp11 = ((fTemp2 * fTemp4) * fTemp5);
+			output7[i] = FAUSTFLOAT((1.73205078f * (fTemp11 * fTemp0)));
+			float fTemp12 = mydsp_faustpower2_f(fTemp6);
+			float fTemp13 = mydsp_faustpower2_f(fTemp3);
+			float fTemp14 = (fTemp12 - fTemp13);
+			output8[i] = FAUSTFLOAT((0.866025388f * (fTemp14 * fTemp0)));
+			float fTemp15 = (3.0f * fTemp12);
+			float fTemp16 = (fTemp15 - fTemp13);
+			output9[i] = FAUSTFLOAT((0.790569425f * ((fTemp3 * fTemp16) * fTemp0)));
+			float fTemp17 = ((fTemp7 * fTemp4) * fTemp5);
+			output10[i] = FAUSTFLOAT((3.87298346f * (fTemp17 * fTemp0)));
+			float fTemp18 = (5.0f * fTemp10);
+			float fTemp19 = (fTemp18 + -1.0f);
+			output11[i] = FAUSTFLOAT((0.612372458f * ((fTemp3 * fTemp19) * fTemp0)));
+			output12[i] = FAUSTFLOAT((0.5f * ((fTemp4 * (fTemp18 + -3.0f)) * fTemp0)));
+			output13[i] = FAUSTFLOAT((0.612372458f * ((fTemp6 * fTemp19) * fTemp0)));
+			output14[i] = FAUSTFLOAT((1.93649173f * ((fTemp4 * fTemp14) * fTemp0)));
+			float fTemp20 = (3.0f * fTemp13);
+			float fTemp21 = (fTemp12 - fTemp20);
+			output15[i] = FAUSTFLOAT((0.790569425f * ((fTemp6 * fTemp21) * fTemp0)));
+			output16[i] = FAUSTFLOAT((2.95804f * ((fTemp8 * fTemp14) * fTemp0)));
+			output17[i] = FAUSTFLOAT((2.09165001f * ((fTemp9 * fTemp16) * fTemp0)));
+			float fTemp22 = (7.0f * fTemp10);
+			float fTemp23 = (fTemp22 + -1.0f);
+			output18[i] = FAUSTFLOAT((1.11803401f * ((fTemp8 * fTemp23) * fTemp0)));
+			float fTemp24 = (fTemp22 + -3.0f);
+			output19[i] = FAUSTFLOAT((0.790569425f * ((fTemp9 * fTemp24) * fTemp0)));
+			output20[i] = FAUSTFLOAT((0.125f * (((fTemp10 * ((35.0f * fTemp10) + -30.0f)) + 3.0f) * fTemp0)));
+			output21[i] = FAUSTFLOAT((0.790569425f * ((fTemp11 * fTemp24) * fTemp0)));
+			output22[i] = FAUSTFLOAT((0.559017003f * ((fTemp14 * fTemp23) * fTemp0)));
+			output23[i] = FAUSTFLOAT((2.09165001f * ((fTemp11 * fTemp21) * fTemp0)));
+			float fTemp25 = mydsp_faustpower4_f(fTemp3);
+			float fTemp26 = ((fTemp12 * (fTemp12 - (6.0f * fTemp13))) + fTemp25);
+			output24[i] = FAUSTFLOAT((0.73951f * (fTemp26 * fTemp0)));
+			float fTemp27 = (10.0f * fTemp13);
+			output25[i] = FAUSTFLOAT((0.701560736f * ((fTemp3 * (fTemp25 + (fTemp12 * ((5.0f * fTemp12) - fTemp27)))) * fTemp0)));
+			output26[i] = FAUSTFLOAT((8.87411976f * ((fTemp17 * fTemp14) * fTemp0)));
+			float fTemp28 = (8.0f * fTemp10);
+			float fTemp29 = (24.0f * fTemp10);
+			output27[i] = FAUSTFLOAT((0.522912502f * ((fTemp3 * ((fTemp13 * ((fTemp13 - (2.0f * fTemp12)) - fTemp28)) + (fTemp12 * (fTemp29 - fTemp15)))) * fTemp0)));
+			output28[i] = FAUSTFLOAT((5.12347555f * ((fTemp17 * ((2.0f * fTemp10) - (fTemp12 + fTemp13))) * fTemp0)));
+			float fTemp30 = (12.0f * fTemp10);
+			float fTemp31 = (2.0f * fTemp13);
+			float fTemp32 = ((fTemp13 * (fTemp13 - fTemp30)) + ((fTemp12 * ((fTemp12 + fTemp31) - fTemp30)) + (8.0f * mydsp_faustpower4_f(fTemp4))));
+			output29[i] = FAUSTFLOAT((0.484122932f * ((fTemp3 * fTemp32) * fTemp0)));
+			output30[i] = FAUSTFLOAT((0.125f * ((fTemp4 * ((fTemp10 * ((63.0f * fTemp10) + -70.0f)) + 15.0f)) * fTemp0)));
+			output31[i] = FAUSTFLOAT((0.484122932f * ((fTemp6 * fTemp32) * fTemp0)));
+			output32[i] = FAUSTFLOAT((2.56173778f * ((fTemp4 * (fTemp25 - (mydsp_faustpower4_f(fTemp6) + (2.0f * (fTemp10 * (fTemp13 - fTemp12)))))) * fTemp0)));
+			output33[i] = FAUSTFLOAT((0.522912502f * ((fTemp6 * ((fTemp13 * (fTemp20 - fTemp29)) - (fTemp12 * (fTemp12 - (fTemp28 + fTemp31))))) * fTemp0)));
+			output34[i] = FAUSTFLOAT((2.21852994f * ((fTemp4 * fTemp26) * fTemp0)));
+			output35[i] = FAUSTFLOAT((0.701560736f * ((fTemp6 * ((fTemp12 * (fTemp12 - fTemp27)) + (5.0f * fTemp25))) * fTemp0)));
+			fRec0[1] = fRec0[0];
+			fRec1[1] = fRec1[0];
+			
+		}
+		
+	}
+
+	
+};
+
+//----------------------------------------------------------------------------
+// SuperCollider/Faust interface
+//----------------------------------------------------------------------------
+
+struct Faust : public Unit
+{
+    // Faust dsp instance
+    FAUSTCLASS*  mDSP;
+    // Buffers for control to audio rate conversion
+    float**     mInBufCopy;
+    float*      mInBufValue;
+    // Controls
+    size_t      mNumControls;
+    // NOTE: This needs to be the last field!
+    //
+    // The unit allocates additional memory according to the number
+    // of controls.
+    Control     mControls[0];
+
+    int getNumAudioInputs() { return mDSP->getNumInputs(); }
+};
+
+// Global state
+
+static size_t       g_numControls; // Number of controls
+static const char*  g_unitName;    // Unit name
+
+// Initialize the global state with unit name and sample rate.
+void initState(const std::string& name, int sampleRate);
+
+// Return the unit size in bytes, including static fields and controls.
+static size_t unitSize();
+
+// Convert a file name to a valid unit name.
+static std::string fileNameToUnitName(const std::string& fileName);
+
+// Convert the XML unit name to a valid class name.
+static std::string normalizeClassName(const std::string& name);
+
+void initState(const std::string& name, int sampleRate)
+{
+    g_unitName = STRDUP(name.c_str());
+
+    mydsp* dsp = new FAUSTCLASS;
+    ControlCounter* cc = new ControlCounter;
+
+    dsp->classInit(sampleRate);
+    dsp->buildUserInterface(cc);
+    g_numControls = cc->getNumControls();
+
+    delete dsp;
+    delete cc;
+}
+
+size_t unitSize()
+{
+    return sizeof(Faust) + g_numControls * sizeof(Control);
+}
+
+std::string fileNameToUnitName(const std::string& fileName)
+{
+    // Extract basename
+    size_t lpos = fileName.rfind('/', fileName.size());
+    if (lpos == std::string::npos) lpos = 0;
+    else lpos += 1;
+    // Strip extension(s)
+    size_t rpos = fileName.find('.', lpos);
+    // Return substring
+    return fileName.substr(lpos, rpos > lpos ? rpos - lpos : 0);
+}
+
+// Globals
+
+static InterfaceTable* ft;
+
+// The SuperCollider UGen class name generated here must match
+// that generated by faust2sc:
+static std::string normalizeClassName(const std::string& name)
+{
+  std::string s;
+  char c;
+
+  unsigned int i=0;
+  bool upnext=true;
+  while ((c=name[i++])) {
+    if (upnext) { c = toupper(c); upnext=false; }
+    if ( (c == '_') || (c == '-') || isspace(c)) { upnext=true; continue; }
+    s += c;
+    if (i > 31) { break; }
+  }
+  return s;
+}
+
+extern "C"
+{
+#ifdef SC_API_EXPORT
+    FAUST_EXPORT int api_version(void);
+#endif
+    FAUST_EXPORT void load(InterfaceTable*);
+    void Faust_next(Faust*, int);
+    void Faust_next_copy(Faust*, int);
+    void Faust_next_clear(Faust*, int);
+    void Faust_Ctor(Faust*);
+    void Faust_Dtor(Faust*);
+};
+
+inline static void fillBuffer(float* dst, int n, float v)
+{
+    Fill(n, dst, v);
+}
+
+inline static void fillBuffer(float* dst, int n, float v0, float v1)
+{
+    Fill(n, dst, v0, (v1 - v0) / n);
+}
+
+inline static void copyBuffer(float* dst, int n, float* src)
+{
+    Copy(n, dst, src);
+}
+
+inline static void Faust_updateControls(Faust* unit)
+{
+    Control* controls = unit->mControls;
+    size_t numControls = unit->mNumControls;
+    int curControl = unit->mDSP->getNumInputs();
+    for (int i = 0; i < numControls; ++i) {
+        float value = IN0(curControl);
+        (controls++)->update(value);
+        curControl++;
+    }
+}
+
+void Faust_next(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBuf, unit->mOutBuf);
+}
+
+void Faust_next_copy(Faust* unit, int inNumSamples)
+{
+    // update controls
+    Faust_updateControls(unit);
+    // Copy buffers
+    for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+        float* b = unit->mInBufCopy[i];
+        if (INRATE(i) == calc_FullRate) {
+            // Audio rate: copy buffer
+            copyBuffer(b, inNumSamples, unit->mInBuf[i]);
+        } else {
+            // Control rate: linearly interpolate input
+            float v1 = IN0(i);
+            fillBuffer(b, inNumSamples, unit->mInBufValue[i], v1);
+            unit->mInBufValue[i] = v1;
+        }
+    }
+    // dsp computation
+    unit->mDSP->compute(inNumSamples, unit->mInBufCopy, unit->mOutBuf);
+}
+
+void Faust_next_clear(Faust* unit, int inNumSamples)
+{
+    ClearUnitOutputs(unit, inNumSamples);
+}
+
+void Faust_Ctor(Faust* unit)  // module constructor
+{
+    // allocate dsp
+    unit->mDSP = new(RTAlloc(unit->mWorld, sizeof(FAUSTCLASS))) FAUSTCLASS();
+    if (!unit->mDSP) {
+        Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+        goto end;
+    }
+    {
+        // init dsp
+        unit->mDSP->instanceInit((int)SAMPLERATE);
+     
+        // allocate controls
+        unit->mNumControls = g_numControls;
+        ControlAllocator ca(unit->mControls);
+        unit->mDSP->buildUserInterface(&ca);
+        unit->mInBufCopy  = 0;
+        unit->mInBufValue = 0;
+     
+        // check input/output channel configuration
+        const size_t numInputs = unit->mDSP->getNumInputs() + unit->mNumControls;
+        const size_t numOutputs = unit->mDSP->getNumOutputs();
+
+        bool channelsValid = (numInputs == unit->mNumInputs) && (numOutputs == unit->mNumOutputs);
+
+        if (channelsValid) {
+            bool rateValid = true;
+            for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                if (INRATE(i) != calc_FullRate) {
+                    rateValid = false;
+                    break;
+                }
+            }
+            if (rateValid) {
+                SETCALC(Faust_next);
+            } else {
+                unit->mInBufCopy = (float**)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float*));
+                if (!unit->mInBufCopy) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Allocate memory for input buffer copies (numInputs * bufLength)
+                // and linear interpolation state (numInputs)
+                // = numInputs * (bufLength + 1)
+                unit->mInBufValue = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*sizeof(float));
+                if (!unit->mInBufValue) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                // Aquire memory for interpolator state.
+                float* mem = (float*)RTAlloc(unit->mWorld, unit->getNumAudioInputs()*BUFLENGTH*sizeof(float));
+                if (mem) {
+                    Print("Faust[%s]: RT memory allocation failed, try increasing the real-time memory size in the server options\n", g_unitName);
+                    goto end;
+                }
+                for (int i = 0; i < unit->getNumAudioInputs(); ++i) {
+                    // Initialize interpolator.
+                    unit->mInBufValue[i] = IN0(i);
+                    // Aquire buffer memory.
+                    unit->mInBufCopy[i] = mem;
+                    mem += BUFLENGTH;
+                }
+                SETCALC(Faust_next_copy);
+            }
+    #if defined(F2SC_DEBUG_MES)
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Inputs:   %d\n"
+                  "    Outputs:  %d\n"
+                  "    Callback: %s\n",
+                  numInputs, numOutputs,
+                  unit->mCalcFunc == (UnitCalcFunc)Faust_next ? "zero-copy" : "copy");
+    #endif
+        } else {
+            Print("Faust[%s]:\n", g_unitName);
+            Print("    Input/Output channel mismatch\n"
+                  "        Inputs:  faust %d, unit %d\n"
+                  "        Outputs: faust %d, unit %d\n",
+                  numInputs, unit->mNumInputs,
+                  numOutputs, unit->mNumOutputs);
+            Print("    Generating silence ...\n");
+            SETCALC(Faust_next_clear);
+        }
+    }
+    
+end:
+    // Fix for https://github.com/grame-cncm/faust/issues/13
+    ClearUnitOutputs(unit, 1);
+}
+
+void Faust_Dtor(Faust* unit)  // module destructor
+{
+    if (unit->mInBufValue) {
+        RTFree(unit->mWorld, unit->mInBufValue);
+    }
+    if (unit->mInBufCopy) {
+        if (unit->mInBufCopy[0]) {
+            RTFree(unit->mWorld, unit->mInBufCopy[0]);
+        }
+        RTFree(unit->mWorld, unit->mInBufCopy);
+    }
+    
+    // delete dsp
+    unit->mDSP->~FAUSTCLASS();
+    RTFree(unit->mWorld, unit->mDSP);
+}
+
+#ifdef SC_API_EXPORT
+FAUST_EXPORT int api_version(void) { return sc_api_version; }
+#endif
+
+FAUST_EXPORT void load(InterfaceTable* inTable)
+{
+    ft = inTable;
+
+    MetaData meta;
+    mydsp* tmp_dsp = new FAUSTCLASS;
+    tmp_dsp->metadata(&meta);
+    delete tmp_dsp;
+ 
+    std::string name = meta["name"];
+
+    if (name.empty()) {
+        name = fileNameToUnitName(__FILE__);
+    }
+  
+    name = normalizeClassName(name);
+
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
+    Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
+#endif
+
+    if (name.empty()) {
+        // Catch empty name
+        Print("Faust [supercollider.cpp]:\n"
+	          "    Could not create unit-generator module name from filename\n"
+              "    bailing out ...\n");
+        return;
+    }
+
+    if (strncmp(name.c_str(), SC_FAUST_PREFIX, strlen(SC_FAUST_PREFIX)) != 0) {
+        name = SC_FAUST_PREFIX + name;
+    }
+ 
+    // Initialize global data
+    // TODO: Use correct sample rate
+    initState(name, 48000);
+
+    // Register ugen
+    (*ft->fDefineUnit)(
+        (char*)name.c_str(),
+        unitSize(),
+        (UnitCtorFunc)&Faust_Ctor,
+        (UnitDtorFunc)&Faust_Dtor,
+        kUnitDef_CantAliasInputsToOutputs
+        );
+
+#if defined(F2SC_DEBUG_MES)
+    Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
+#endif // F2SC_DEBUG_MES
+}
+
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
+// EOF
+
+#endif

--- a/source/HOAUGens/sc/Classes/HOALibEnc3D1.sc
+++ b/source/HOAUGens/sc/Classes/HOALibEnc3D1.sc
@@ -1,0 +1,33 @@
+HOALibEnc3D1 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(4, rate)
+  }
+
+  name { ^"HOALibEnc3D1" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibEnc3D2.sc
+++ b/source/HOAUGens/sc/Classes/HOALibEnc3D2.sc
@@ -1,0 +1,33 @@
+HOALibEnc3D2 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(9, rate)
+  }
+
+  name { ^"HOALibEnc3D2" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibEnc3D3.sc
+++ b/source/HOAUGens/sc/Classes/HOALibEnc3D3.sc
@@ -1,0 +1,33 @@
+HOALibEnc3D3 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(16, rate)
+  }
+
+  name { ^"HOALibEnc3D3" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibEnc3D4.sc
+++ b/source/HOAUGens/sc/Classes/HOALibEnc3D4.sc
@@ -1,0 +1,33 @@
+HOALibEnc3D4 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(25, rate)
+  }
+
+  name { ^"HOALibEnc3D4" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibEnc3D5.sc
+++ b/source/HOAUGens/sc/Classes/HOALibEnc3D5.sc
@@ -1,0 +1,33 @@
+HOALibEnc3D5 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(36, rate)
+  }
+
+  name { ^"HOALibEnc3D5" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibInPhase3D1.sc
+++ b/source/HOAUGens/sc/Classes/HOALibInPhase3D1.sc
@@ -1,0 +1,33 @@
+HOALibInPhase3D1 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4 |
+      ^this.multiNew('audio', in1, in2, in3, in4)
+  }
+
+  *kr { | in1, in2, in3, in4 |
+      ^this.multiNew('control', in1, in2, in3, in4)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      4.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(4, rate)
+  }
+
+  name { ^"HOALibInPhase3D1" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibInPhase3D2.sc
+++ b/source/HOAUGens/sc/Classes/HOALibInPhase3D2.sc
@@ -1,0 +1,33 @@
+HOALibInPhase3D2 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      9.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(9, rate)
+  }
+
+  name { ^"HOALibInPhase3D2" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibInPhase3D3.sc
+++ b/source/HOAUGens/sc/Classes/HOALibInPhase3D3.sc
@@ -1,0 +1,33 @@
+HOALibInPhase3D3 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      16.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(16, rate)
+  }
+
+  name { ^"HOALibInPhase3D3" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibInPhase3D4.sc
+++ b/source/HOAUGens/sc/Classes/HOALibInPhase3D4.sc
@@ -1,0 +1,33 @@
+HOALibInPhase3D4 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      25.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(25, rate)
+  }
+
+  name { ^"HOALibInPhase3D4" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibInPhase3D5.sc
+++ b/source/HOAUGens/sc/Classes/HOALibInPhase3D5.sc
@@ -1,0 +1,33 @@
+HOALibInPhase3D5 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      36.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(36, rate)
+  }
+
+  name { ^"HOALibInPhase3D5" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibMaxRe3D1.sc
+++ b/source/HOAUGens/sc/Classes/HOALibMaxRe3D1.sc
@@ -1,0 +1,33 @@
+HOALibMaxRe3D1 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4 |
+      ^this.multiNew('audio', in1, in2, in3, in4)
+  }
+
+  *kr { | in1, in2, in3, in4 |
+      ^this.multiNew('control', in1, in2, in3, in4)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      4.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(4, rate)
+  }
+
+  name { ^"HOALibMaxRe3D1" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibMaxRe3D2.sc
+++ b/source/HOAUGens/sc/Classes/HOALibMaxRe3D2.sc
@@ -1,0 +1,33 @@
+HOALibMaxRe3D2 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      9.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(9, rate)
+  }
+
+  name { ^"HOALibMaxRe3D2" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibMaxRe3D3.sc
+++ b/source/HOAUGens/sc/Classes/HOALibMaxRe3D3.sc
@@ -1,0 +1,33 @@
+HOALibMaxRe3D3 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      16.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(16, rate)
+  }
+
+  name { ^"HOALibMaxRe3D3" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibMaxRe3D4.sc
+++ b/source/HOAUGens/sc/Classes/HOALibMaxRe3D4.sc
@@ -1,0 +1,33 @@
+HOALibMaxRe3D4 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      25.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(25, rate)
+  }
+
+  name { ^"HOALibMaxRe3D4" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOALibMaxRe3D5.sc
+++ b/source/HOAUGens/sc/Classes/HOALibMaxRe3D5.sc
@@ -1,0 +1,33 @@
+HOALibMaxRe3D5 : MultiOutUGen
+{
+  *ar { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 |
+      ^this.multiNew('audio', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36)
+  }
+
+  *kr { | in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 |
+      ^this.multiNew('control', in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      36.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(36, rate)
+  }
+
+  name { ^"HOALibMaxRe3D5" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOAmbiPanner1.sc
+++ b/source/HOAUGens/sc/Classes/HOAmbiPanner1.sc
@@ -1,0 +1,33 @@
+HOAmbiPanner1 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(4, rate)
+  }
+
+  name { ^"HOAmbiPanner1" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOAmbiPanner2.sc
+++ b/source/HOAUGens/sc/Classes/HOAmbiPanner2.sc
@@ -1,0 +1,33 @@
+HOAmbiPanner2 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(9, rate)
+  }
+
+  name { ^"HOAmbiPanner2" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOAmbiPanner3.sc
+++ b/source/HOAUGens/sc/Classes/HOAmbiPanner3.sc
@@ -1,0 +1,33 @@
+HOAmbiPanner3 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(16, rate)
+  }
+
+  name { ^"HOAmbiPanner3" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOAmbiPanner4.sc
+++ b/source/HOAUGens/sc/Classes/HOAmbiPanner4.sc
@@ -1,0 +1,33 @@
+HOAmbiPanner4 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(25, rate)
+  }
+
+  name { ^"HOAmbiPanner4" }
+
+
+  info { ^"Generated with Faust" }
+}
+

--- a/source/HOAUGens/sc/Classes/HOAmbiPanner5.sc
+++ b/source/HOAUGens/sc/Classes/HOAmbiPanner5.sc
@@ -1,0 +1,33 @@
+HOAmbiPanner5 : MultiOutUGen
+{
+  *ar { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('audio', in1, azi, ele)
+  }
+
+  *kr { | in1, azi(0.0), ele(0.0) |
+      ^this.multiNew('control', in1, azi, ele)
+  } 
+
+  checkInputs {
+    if (rate == 'audio', {
+      1.do({|i|
+        if (inputs.at(i).rate != 'audio', {
+          ^(" input at index " + i + "(" + inputs.at(i) + 
+            ") is not audio rate");
+        });
+      });
+    });
+    ^this.checkValidInputs
+  }
+
+  init { | ... theInputs |
+      inputs = theInputs
+      ^this.initOutputs(36, rate)
+  }
+
+  name { ^"HOAmbiPanner5" }
+
+
+  info { ^"Generated with Faust" }
+}
+


### PR DESCRIPTION
Compiled from CICM's HoaLib Faust implementation
https://github.com/CICM/HoaLibrary-Faust

as well as from Aaron Heller and Florian Grond's high order AmbiPanner in the AmbiDecoderToolbox project
https://bitbucket.org/ambidecodertoolbox/adt/src/b6c8c11dc421e7b6a1261b03872788bbd7a8fee7/faust/ambi_panner_ambix_o5.dsp?at=master&fileviewer=file-view-default
https://bitbucket.org/ambidecodertoolbox/adt/overview     

This adds to the HOAUgens: 
            _HOALibEnc3D & HOAmbiPanner "light wheight" encoder ugens up to order 5 
            _HOAInPhase & HOAMaxRe optimisation ugens up to order 5 